### PR TITLE
refatorar construtor da interface de atributos para aceitar parâmetros variáveis

### DIFF
--- a/api/Interface/AttributesInterface.php
+++ b/api/Interface/AttributesInterface.php
@@ -12,7 +12,7 @@ namespace Bifrost\Interface;
  */
 interface AttributesInterface
 {
-    public function __construct();
+    public function __construct(...$params);
 
     public function __destruct();
 


### PR DESCRIPTION
refatorar construtor da interface de atributos para aceitar parâmetros variáveis