### PR TITLE
Atualiza atributo Cache

### DIFF
--- a/api/Attributes/Cache.php
+++ b/api/Attributes/Cache.php
@@ -12,9 +12,10 @@ use Bifrost\Interface\AttributesInterface;
 
 /**
  * Cache constructor.
- * @param string $key
- * @param int $time
- * @param array $fieldsSession
+ *
+ * @param int $time Tempo em segundos que o cache ficará salvo.
+ * @param array $fieldsSession Campos da sessão que serão levados em conta ao gerar a chave.
+ * @param array $extra Array de valores extras utilizados para compor a chave.
  * @return void
  */
 #[Attribute]
@@ -26,17 +27,24 @@ class Cache implements AttributesInterface
     private int $time;
     private CoreCache $cache;
 
-    public function __construct(...$p)
+    public function __construct(int $time, array $fieldsSession = [], array $extra = [])
     {
         $post = new Post();
         $get = new Get();
-        $this->key = serialize([
-            "key" => $p[0],
-            "POST" => (string)$post,
-            "GET" => (string)$get,
-            "SESSION" => $this->getFieldsSession($p[2] ?? []),
-        ]);
-        $this->time = $p[1];
+
+        $dataKey = [
+            "METHOD" => $_SERVER['REQUEST_METHOD'] ?? 'GET',
+            "POST" => (string) $post,
+            "GET" => (string) $get,
+            "SESSION" => $this->getFieldsSession($fieldsSession),
+        ];
+
+        if (!empty($extra)) {
+            $dataKey["EXTRA"] = serialize($extra);
+        }
+
+        $this->key = serialize($dataKey);
+        $this->time = $time;
         $this->cache = new CoreCache();
     }
 

--- a/api/Controller/index.php
+++ b/api/Controller/index.php
@@ -15,7 +15,7 @@ use Bifrost\Interface\ControllerInterface;
 class Index implements ControllerInterface
 {
 
-    #[Cache("index-data", 20)]
+    #[Cache(20)]
     public function index()
     {
         switch ($_SERVER["REQUEST_METHOD"]) {
@@ -30,7 +30,7 @@ class Index implements ControllerInterface
 
     #[Method("OPTIONS")]
     #[Details(["description" => "Lista informações do recurso"])]
-    #[Cache("options_recurso", 60)]
+    #[Cache(60)]
     public function options_recurso()
     {
         return HttpResponse::success(
@@ -46,7 +46,7 @@ class Index implements ControllerInterface
     #[Details([
         "description" => "lista um recurso",
     ])]
-    #[Cache("get_recurso", 60)]
+    #[Cache(60)]
     #[RequiredParams([
         "id" => Field::UUID
     ])]


### PR DESCRIPTION
## Summary
- melhorar construtor do atributo Cache para incluir o método da requisição e aceitar tempo, campos de sessão e valores extras
- ajustar uso do atributo nos controllers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68430e248c48832fa135701681c6a95d