### PR TITLE
Corrige mounts do devcontainer e trigger do xdebug para o nginx

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,6 +6,9 @@
     "dockerfile": "Dockerfile",
     "context": ".."
   },
+  "containerEnv": {
+    "BIFROST_WORKSPACE": "${localWorkspaceFolder}"
+  },
   "features": {
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
       "moby": false

--- a/api/Docker/Dockerfile.dev
+++ b/api/Docker/Dockerfile.dev
@@ -42,7 +42,7 @@ RUN pecl install xdebug \
     && mkdir -p /var/log/xdebug \
     && echo "zend_extension=$(find /usr/local/lib/php/extensions/ -name xdebug.so)" > /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.mode=debug,develop" >> /usr/local/etc/php/conf.d/xdebug.ini \
-    && echo "xdebug.start_with_request=yes" >> /usr/local/etc/php/conf.d/xdebug.ini \
+    && echo "xdebug.start_with_request=trigger" >> /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.client_host=host.docker.internal" >> /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.client_port=9003" >> /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.log=/var/log/xdebug.log" >> /usr/local/etc/php/conf.d/xdebug.ini \

--- a/api/Docker/docker-compose.dev.yml
+++ b/api/Docker/docker-compose.dev.yml
@@ -8,8 +8,8 @@ x-template-api:
     env_file:
       - ./../../.env
     volumes:
-      - ../:/var/www/html
-      - ../composer.json:/tmp/composer.json:ro
+      - ${BIFROST_WORKSPACE:-../..}/api:/var/www/html
+      - ${BIFROST_WORKSPACE:-../..}/api/composer.json:/tmp/composer.json:ro
       - api_vendor:/var/www/html/vendor
     networks:
       - bifrost-back-network
@@ -26,6 +26,8 @@ services:
     depends_on:
       - api1
       - api2
+    volumes:
+      - ${BIFROST_WORKSPACE:-../..}/api:/var/www/html:ro
     networks:
       - bifrost-back-network
 


### PR DESCRIPTION
## Summary\n- ensure devcontainer passes BIFROST_WORKSPACE so compose binds real api source\n- fix compose dev volumes and mount api code into nginx to serve index.php\n- set xdebug to start_on_request=trigger to avoid blocking php-fpm\n\n## Testing\n- docker compose -f api/Docker/docker-compose.dev.yml up -d\n- curl.exe --max-time 5 -i http://localhost/