### PR TITLE
Otimiza Settings, padroniza envs e adiciona cache APCu para settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 ##// CONFIGURAÇÕES DA API BIFROST
-#BFR_API_DISPLAY_ERRORS=1
+#BFR_API_PHP_DISPLAY_ERRORS=1
 
 #// Configurações da sessão
 #// Descomente as linhas abaixo para usar o Redis como handler de sessão
@@ -12,8 +12,10 @@
 #// Descomente as linhas abaixo para usar o Redis como cache
 #BFR_API_REDIS_HOST=redis
 #BFR_API_REDIS_PORT=6379
-#BFR_API_APCU_ENABLED=true
-#BFR_API_APCU_TTL=3600
+#BFR_API_CACHE_APCU_ENABLED=true
+#BFR_API_CACHE_APCU_TTL=3600
+#BFR_API_SETTINGS_APCU_ENABLED=true
+#BFR_API_SETTINGS_APCU_TTL=60
 #CACHE_QUERY_TIME=40
 
 #// Configuração do redis para fila de tarefas
@@ -21,12 +23,12 @@
 
 #// Configuração de banco de dados
 #// Descomente as linhas abaixo para usar o PostgreSQL como banco de dados
-#BFR_API_SQL_DRIVER=PostgreSQL
-#BFR_API_SQL_HOST=database
-#BFR_API_SQL_PORT=5432
-#BFR_API_SQL_DATABASE=bifrost
-#BFR_API_SQL_USER=bifrost
-#BFR_API_SQL_PASSWORD=passwordBifrost
+#BFR_API_DB_DRIVER=PostgreSQL
+#BFR_API_DB_HOST=database
+#BFR_API_DB_PORT=5432
+#BFR_API_DB_NAME=bifrost
+#BFR_API_DB_USER=bifrost
+#BFR_API_DB_PASSWORD=passwordBifrost
 
 #// Configuracao opcional de storage S3 (AWS SDK)
 #BFR_API_S3_BUCKET=meu-bucket

--- a/README.md
+++ b/README.md
@@ -150,17 +150,21 @@ Principais variaveis:
 
 | Nome | Uso |
 |------|-----|
-| `BFR_API_DISPLAY_ERRORS` | Liga ou desliga exibicao de erros do PHP |
+| `BFR_API_PHP_DISPLAY_ERRORS` | Liga ou desliga exibicao de erros do PHP |
 | `BFR_API_SESSION_SAVE_HANDLER` | Handler de sessao |
 | `BFR_API_SESSION_SAVE_PATH` | Local de persistencia de sessao |
 | `BFR_API_SESSION_GC_MAXLIFETIME` | TTL da sessao |
 | `BFR_API_SESSION_COOKIE_LIFETIME` | TTL do cookie de sessao |
-| `BFR_API_SQL_DRIVER` | Driver do banco: `sqlite`, `mysql` ou `pgsql` |
-| `BFR_API_SQL_HOST` | Host do banco |
-| `BFR_API_SQL_PORT` | Porta do banco |
-| `BFR_API_SQL_DATABASE` | Nome do banco ou path do arquivo SQLite |
-| `BFR_API_SQL_USER` | Usuario do banco |
-| `BFR_API_SQL_PASSWORD` | Senha do banco |
+| `BFR_API_DB_DRIVER` | Driver do banco: `sqlite`, `mysql` ou `pgsql` |
+| `BFR_API_DB_HOST` | Host do banco |
+| `BFR_API_DB_PORT` | Porta do banco |
+| `BFR_API_DB_NAME` | Nome do banco ou path do arquivo SQLite |
+| `BFR_API_DB_USER` | Usuario do banco |
+| `BFR_API_DB_PASSWORD` | Senha do banco |
+| `BFR_API_CACHE_APCU_ENABLED` | Habilita cache APCu para metadata de request |
+| `BFR_API_CACHE_APCU_TTL` | TTL em segundos para cache APCu de metadata |
+| `BFR_API_SETTINGS_APCU_ENABLED` | Habilita cache APCu para leitura de settings (nao-CLI) |
+| `BFR_API_SETTINGS_APCU_TTL` | TTL em segundos para cache APCu de settings |
 | `BFR_API_REDIS_HOST` | Host do Redis |
 | `BFR_API_REDIS_PORT` | Porta do Redis |
 | `BFR_API_REDIS_QUEUE` | Nome da fila Redis |
@@ -174,6 +178,8 @@ Principais variaveis:
 | `BFR_API_HTTP_PORT` | Porta exposta pelo Nginx em producao |
 
 O arquivo [`.env.example`](/workspaces/Bifrost-API/.env.example) tem um ponto de partida para configuracao local.
+
+> Compatibilidade retroativa: os aliases legados (`BFR_API_DISPLAY_ERRORS`, `BFR_API_SQL_*` e `BFR_API_APCU_*`) continuam aceitos para manter compatibilidade.
 
 ## Como funciona o request
 

--- a/api/Core/Settings.php
+++ b/api/Core/Settings.php
@@ -22,6 +22,7 @@ final class Settings
 {
     /** It is responsible for controlling the initialization of the settings. */
     private static bool $initialized = false;
+    private static array $requestEnvCache = [];
 
     /**
      * It is responsible for initializing the settings.
@@ -60,6 +61,21 @@ final class Settings
      */
     protected static function getEnv(string $param, bool $required = false): mixed
     {
+        $cacheKey = $param . ':' . ($required ? '1' : '0');
+        if (array_key_exists($cacheKey, self::$requestEnvCache)) {
+            return self::$requestEnvCache[$cacheKey];
+        }
+
+        $apcuKey = "settings:env:{$cacheKey}";
+        if (self::settingsApcuEnabled() && function_exists('apcu_fetch')) {
+            $success = false;
+            $cached = apcu_fetch($apcuKey, $success);
+            if ($success) {
+                self::$requestEnvCache[$cacheKey] = $cached;
+                return $cached;
+            }
+        }
+
         $value = getenv($param);
 
         if ($required && ($value === false || $value === '')) {
@@ -69,7 +85,94 @@ final class Settings
             ));
         }
 
-        return $value === false ? null : $value;
+        $parsedValue = $value === false ? null : $value;
+        self::$requestEnvCache[$cacheKey] = $parsedValue;
+        if (self::settingsApcuEnabled() && function_exists('apcu_store')) {
+            apcu_store($apcuKey, $parsedValue, self::settingsApcuTtl());
+        }
+
+        return $parsedValue;
+    }
+
+    /**
+     * It is responsible for returning the first non-empty environment variable value.
+     *
+     * @param array $params The environment variable aliases.
+     * @param bool $required Indicates whether one alias is required.
+     * @return mixed
+     */
+    protected static function getEnvFromAliases(array $params, bool $required = false): mixed
+    {
+        foreach ($params as $param) {
+            $value = static::getEnv($param);
+            if ($value !== null && $value !== '') {
+                return $value;
+            }
+        }
+
+        if ($required && !empty($params)) {
+            return static::getEnv($params[0], true);
+        }
+
+        return null;
+    }
+
+    /**
+     * Parse env booleans in a safer way.
+     *
+     * @param mixed $value The env value.
+     * @param bool $default Default value when parsing fails.
+     * @return bool
+     */
+    private static function parseEnvBool(mixed $value, bool $default = false): bool
+    {
+        if ($value === null || $value === '') {
+            return $default;
+        }
+
+        return filter_var($value, FILTER_VALIDATE_BOOL, FILTER_NULL_ON_FAILURE) ?? $default;
+    }
+
+    /**
+     * It is responsible for enabling APCu settings cache (non-CLI only).
+     *
+     * @return bool
+     */
+    private static function settingsApcuEnabled(): bool
+    {
+        if (PHP_SAPI === 'cli') {
+            return false;
+        }
+
+        $enabledRaw = getenv('BFR_API_SETTINGS_APCU_ENABLED');
+        if ($enabledRaw === false || $enabledRaw === '') {
+            $enabledRaw = getenv('BFR_API_CACHE_APCU_ENABLED');
+        }
+        if ($enabledRaw === false || $enabledRaw === '') {
+            $enabledRaw = getenv('BFR_API_APCU_ENABLED');
+        }
+        $enabled = static::parseEnvBool($enabledRaw === false ? null : $enabledRaw, false);
+
+        return $enabled && function_exists('apcu_enabled') ? apcu_enabled() : $enabled;
+    }
+
+    /**
+     * It is responsible for returning APCu settings cache TTL.
+     *
+     * @return int
+     */
+    private static function settingsApcuTtl(): int
+    {
+        $ttlRaw = getenv('BFR_API_SETTINGS_APCU_TTL');
+        if ($ttlRaw === false || $ttlRaw === '') {
+            $ttlRaw = getenv('BFR_API_CACHE_APCU_TTL');
+        }
+        if ($ttlRaw === false || $ttlRaw === '') {
+            $ttlRaw = getenv('BFR_API_APCU_TTL');
+        }
+        $ttl = (int) ($ttlRaw === false ? 60 : $ttlRaw);
+
+        return $ttl > 0 ? $ttl : 60;
     }
 
     /**
@@ -97,8 +200,12 @@ final class Settings
      */
     private static function iniSet(): void
     {
-        ini_set("display_errors", (bool) static::getEnv("BFR_API_DISPLAY_ERRORS") ?? false);
-        ini_set("display_startup_errors", (bool) static::getEnv("BFR_API_DISPLAY_ERRORS") ?? false);
+        $displayErrors = static::parseEnvBool(
+            static::getEnvFromAliases(['BFR_API_PHP_DISPLAY_ERRORS', 'BFR_API_DISPLAY_ERRORS']),
+            false
+        );
+        ini_set("display_errors", $displayErrors ? '1' : '0');
+        ini_set("display_startup_errors", $displayErrors ? '1' : '0');
 
         if (session_status() === PHP_SESSION_ACTIVE) {
             return;
@@ -146,15 +253,34 @@ final class Settings
             $databaseName = strtoupper($databaseName) . "_";
         }
 
-        $isNotSqlite = static::getEnv("{$prefix}{$databaseName}SQL_DRIVER", true) !== "sqlite";
+        $driver = static::getEnvFromAliases([
+            "{$prefix}{$databaseName}DB_DRIVER",
+            "{$prefix}{$databaseName}SQL_DRIVER",
+        ], true);
+        $isNotSqlite = $driver !== "sqlite";
 
         return [
-            "driver" => static::getEnv("{$prefix}{$databaseName}SQL_DRIVER", true),
-            "host" => static::getEnv("{$prefix}{$databaseName}SQL_HOST", $isNotSqlite),
-            "port" => static::getEnv("{$prefix}{$databaseName}SQL_PORT", $isNotSqlite),
-            "database" => static::getEnv("{$prefix}{$databaseName}SQL_DATABASE", true),
-            "username" => static::getEnv("{$prefix}{$databaseName}SQL_USER", $isNotSqlite),
-            "password" => static::getEnv("{$prefix}{$databaseName}SQL_PASSWORD", $isNotSqlite),
+            "driver" => $driver,
+            "host" => static::getEnvFromAliases([
+                "{$prefix}{$databaseName}DB_HOST",
+                "{$prefix}{$databaseName}SQL_HOST",
+            ], $isNotSqlite),
+            "port" => static::getEnvFromAliases([
+                "{$prefix}{$databaseName}DB_PORT",
+                "{$prefix}{$databaseName}SQL_PORT",
+            ], $isNotSqlite),
+            "database" => static::getEnvFromAliases([
+                "{$prefix}{$databaseName}DB_NAME",
+                "{$prefix}{$databaseName}SQL_DATABASE",
+            ], true),
+            "username" => static::getEnvFromAliases([
+                "{$prefix}{$databaseName}DB_USER",
+                "{$prefix}{$databaseName}SQL_USER",
+            ], $isNotSqlite),
+            "password" => static::getEnvFromAliases([
+                "{$prefix}{$databaseName}DB_PASSWORD",
+                "{$prefix}{$databaseName}SQL_PASSWORD",
+            ], $isNotSqlite),
         ];
     }
 }

--- a/api/Integration/Apcu.php
+++ b/api/Integration/Apcu.php
@@ -82,7 +82,7 @@ class Apcu
     private static function enabled(): bool
     {
         $settings = new Settings();
-        $enabled = $settings->BFR_API_APCU_ENABLED;
+        $enabled = $settings->BFR_API_CACHE_APCU_ENABLED ?? $settings->BFR_API_APCU_ENABLED;
 
         if ($enabled === null || $enabled === '') {
             return true;
@@ -94,7 +94,7 @@ class Apcu
     private static function defaultTtl(): int
     {
         $settings = new Settings();
-        $ttl = (int) ($settings->BFR_API_APCU_TTL ?? 3600);
+        $ttl = (int) ($settings->BFR_API_CACHE_APCU_TTL ?? $settings->BFR_API_APCU_TTL ?? 3600);
 
         return $ttl > 0 ? $ttl : 3600;
     }

--- a/api/tests/Core/RequestTest.php
+++ b/api/tests/Core/RequestTest.php
@@ -142,7 +142,7 @@ final class RequestTest extends TestCase
 
     public function testRequestDoesNotCacheMetadataWhenApcuIsDisabled(): void
     {
-        putenv('BFR_API_APCU_ENABLED=0');
+        putenv('BFR_API_CACHE_APCU_ENABLED=0');
 
         $controller = new class implements Controller {
             #[Method('GET')]
@@ -162,7 +162,7 @@ final class RequestTest extends TestCase
 
         self::assertNull(Apcu::fetch($cacheKey));
 
-        putenv('BFR_API_APCU_ENABLED=1');
+        putenv('BFR_API_CACHE_APCU_ENABLED=1');
     }
 
     public function testHydrateAttributesKeepsOptionsWhenLoadedFromCache(): void

--- a/api/tests/Core/SettingsTest.php
+++ b/api/tests/Core/SettingsTest.php
@@ -10,16 +10,28 @@ final class SettingsTest extends TestCase
 {
     public function testReadsEnvironmentVariablesAndDatabaseSettings(): void
     {
+        putenv('BFR_API_DB_DRIVER=sqlite');
+        putenv('BFR_API_DB_NAME=' . bifrost_sqlite_path());
+
+        $settings = new Settings();
+        $config = $settings->getSettingsDatabase();
+
+        self::assertSame('sqlite', $settings->BFR_API_DB_DRIVER);
+        self::assertSame('sqlite', $config['driver']);
+        self::assertSame(bifrost_sqlite_path(), $config['database']);
+        self::assertNull($config['host']);
+    }
+
+    public function testLegacySqlEnvironmentVariablesStillWork(): void
+    {
         putenv('BFR_API_SQL_DRIVER=sqlite');
         putenv('BFR_API_SQL_DATABASE=' . bifrost_sqlite_path());
 
         $settings = new Settings();
         $config = $settings->getSettingsDatabase();
 
-        self::assertSame('sqlite', $settings->BFR_API_SQL_DRIVER);
         self::assertSame('sqlite', $config['driver']);
         self::assertSame(bifrost_sqlite_path(), $config['database']);
-        self::assertNull($config['host']);
     }
 
     public function testMissingRequiredEnvironmentVariableThrowsAppError(): void

--- a/api/tests/bootstrap.php
+++ b/api/tests/bootstrap.php
@@ -14,19 +14,21 @@ use Bifrost\Core\Post;
 use Bifrost\Core\Session;
 use Bifrost\Integration\Database\PdoDatabase;
 
-putenv('BFR_API_DISPLAY_ERRORS=0');
+putenv('BFR_API_PHP_DISPLAY_ERRORS=0');
 putenv('BFR_API_SESSION_SAVE_HANDLER=files');
 putenv('BFR_API_SESSION_SAVE_PATH=/tmp');
-putenv('BFR_API_SQL_DRIVER=sqlite');
-putenv('BFR_API_SQL_DATABASE=' . sys_get_temp_dir() . '/bifrost-api-phpunit.sqlite');
-putenv('BFR_API_SQL_USER');
-putenv('BFR_API_SQL_PASSWORD');
-putenv('BFR_API_SQL_HOST');
-putenv('BFR_API_SQL_PORT');
+putenv('BFR_API_DB_DRIVER=sqlite');
+putenv('BFR_API_DB_NAME=' . sys_get_temp_dir() . '/bifrost-api-phpunit.sqlite');
+putenv('BFR_API_DB_USER');
+putenv('BFR_API_DB_PASSWORD');
+putenv('BFR_API_DB_HOST');
+putenv('BFR_API_DB_PORT');
 putenv('BFR_API_REDIS_HOST');
 putenv('BFR_API_REDIS_PORT');
-putenv('BFR_API_APCU_ENABLED=1');
-putenv('BFR_API_APCU_TTL=3600');
+putenv('BFR_API_CACHE_APCU_ENABLED=1');
+putenv('BFR_API_CACHE_APCU_TTL=3600');
+putenv('BFR_API_SETTINGS_APCU_ENABLED=0');
+putenv('BFR_API_SETTINGS_APCU_TTL=60');
 putenv('BFR_API_REDIS_QUEUE');
 putenv('BFR_API_S3_BUCKET');
 putenv('BFR_API_S3_REGION');
@@ -42,7 +44,7 @@ $_SESSION = [];
 
 function bifrost_sqlite_path(): string
 {
-    return (string) getenv('BFR_API_SQL_DATABASE');
+    return (string) (getenv('BFR_API_DB_NAME') ?: getenv('BFR_API_SQL_DATABASE'));
 }
 
 function bifrost_reset_pdo_connections(): void


### PR DESCRIPTION
### Motivation
- Melhorar performance e consistência na leitura de variáveis de ambiente no `Settings` e padronizar nomes das variáveis de ambiente para tornar a configuração mais clara. 
- Permitir cache opcional de leitura de settings via APCu (somente em execução web, não-CLI) para reduzir overhead em leitura repetida de env. 
- Manter compatibilidade retroativa com os nomes legados (`BFR_API_SQL_*`, `BFR_API_APCU_*`, `BFR_API_DISPLAY_ERRORS`).

### Description
- Adiciona cache por request em `api/Core/Settings.php` e suporte opcional a APCu para cache de settings com TTL configurável e desabilitado em `cli` via `settingsApcuEnabled()` e `settingsApcuTtl()`; também introduz `getEnvFromAliases()` e `parseEnvBool()` para aliases e parsing seguro. 
- Padroniza variáveis de ambiente de banco para `BFR_API_DB_*` e de display errors para `BFR_API_PHP_DISPLAY_ERRORS`, enquanto mantém fallback para `BFR_API_SQL_*` e `BFR_API_DISPLAY_ERRORS`. 
- Atualiza a integração de APCu (`api/Integration/Apcu.php`) para preferir `BFR_API_CACHE_APCU_*` com fallback para os nomes legados e ajusta TTL fallback. 
- Atualiza testes e bootstrap (`api/tests/*`) para usar os novos nomes, adiciona teste garantindo compatibilidade com variáveis legadas, e atualiza `.env.example` e `README.md` com os novos nomes e nota sobre compatibilidade retroativa.

### Testing
- Executados checagens de sintaxe com `php -l` para `api/Core/Settings.php`, `api/Integration/Apcu.php`, `api/tests/Core/SettingsTest.php`, `api/tests/bootstrap.php` e `api/tests/Core/RequestTest.php`, todas sem erros. 
- Tentativa de rodar `phpunit` com `cd api && ./vendor/bin/phpunit --filter SettingsTest` não foi executada por ausência do binário `vendor/bin/phpunit` no ambiente, portanto os testes automatizados não foram completados aqui.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8a58abe54832f8cb59aec012d2566)