### PR TITLE
Refatora settings e cache APCu

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,37 +1,37 @@
-##// CONFIGURAÇÕES DA API BIFROST
-#BFR_API_DISPLAY_ERRORS=1
+## Bifrost API settings
+#BFR_API_DEBUG_SHOW_ERRORS=1               # 1 para exibir erros (desenvolvimento), 0 para esconder (producao)
 
-#// Configurações da sessão
-#// Descomente as linhas abaixo para usar o Redis como handler de sessão
-#BFR_API_SESSION_SAVE_HANDLER=redis
-#BFR_API_SESSION_SAVE_PATH=tcp://redis:6379
-#BFR_API_SESSION_GC_MAXLIFETIME=43200
-#BFR_API_SESSION_COOKIE_LIFETIME=43200
+# Sessao
+#BFR_API_SESSION_HANDLER=files             # files ou redis
+#BFR_API_SESSION_PATH=/var/lib/php/sessions
+#BFR_API_SESSION_TTL=1440                  # segundos para expirar a sessao
+#BFR_API_SESSION_COOKIE_TTL=0              # segundos do cookie; 0 = dura ate fechar o navegador
 
-#// Configuração do redis para cache
-#// Descomente as linhas abaixo para usar o Redis como cache
-#BFR_API_REDIS_HOST=redis
-#BFR_API_REDIS_PORT=6379
-#BFR_API_APCU_ENABLED=true
-#BFR_API_APCU_TTL=3600
-#CACHE_QUERY_TIME=40
+# Cache
+#BFR_API_CACHE_DRIVER=apcu                 # apcu | redis | none
+#BFR_API_CACHE_APCU_ENABLED=1              # habilita APCu para metadados/autoloader
+#BFR_API_CACHE_APCU_TTL=3600               # TTL padrao em segundos para o APCu
+#BFR_API_CACHE_REDIS_HOST=redis
+#BFR_API_CACHE_REDIS_PORT=6379
+#BFR_API_CACHE_QUERY_TTL=40                # TTL para caches de consultas
 
-#// Configuração do redis para fila de tarefas
-#BFR_API_REDIS_QUEUE=queue
+# Fila
+#BFR_API_QUEUE_NAME=bifrost_queue
+#BFR_API_QUEUE_REDIS_HOST=redis
+#BFR_API_QUEUE_REDIS_PORT=6379
 
-#// Configuração de banco de dados
-#// Descomente as linhas abaixo para usar o PostgreSQL como banco de dados
-#BFR_API_SQL_DRIVER=PostgreSQL
-#BFR_API_SQL_HOST=database
-#BFR_API_SQL_PORT=5432
-#BFR_API_SQL_DATABASE=bifrost
-#BFR_API_SQL_USER=bifrost
-#BFR_API_SQL_PASSWORD=passwordBifrost
+# Banco de dados
+#BFR_API_DB_DRIVER=pgsql                   # sqlite | mysql | pgsql
+#BFR_API_DB_HOST=database
+#BFR_API_DB_PORT=5432
+#BFR_API_DB_NAME=bifrost
+#BFR_API_DB_USER=bifrost
+#BFR_API_DB_PASSWORD=passwordBifrost
 
-#// Configuracao opcional de storage S3 (AWS SDK)
+# Storage S3 opcional
 #BFR_API_S3_BUCKET=meu-bucket
 #BFR_API_S3_REGION=us-east-1
 #BFR_API_S3_KEY=
 #BFR_API_S3_SECRET=
-#BFR_API_S3_ENDPOINT=
-#BFR_API_S3_PATH_STYLE=false
+#BFR_API_S3_ENDPOINT=                      # exemplo: https://s3.sa-east-1.amazonaws.com
+#BFR_API_S3_PATH_STYLE=false               # true para forcar path-style

--- a/api/Core/Autoload.php
+++ b/api/Core/Autoload.php
@@ -9,7 +9,14 @@ $composerAutoloadCandidates = [
 
 foreach ($composerAutoloadCandidates as $composerAutoload) {
     if (is_readable($composerAutoload)) {
-        require_once $composerAutoload;
+        $loader = require_once $composerAutoload;
+
+        if ($loader instanceof \Composer\Autoload\ClassLoader) {
+            $apcuEnabled = filter_var(getenv('BFR_API_CACHE_APCU_ENABLED'), FILTER_VALIDATE_BOOL, FILTER_NULL_ON_FAILURE);
+            if ($apcuEnabled === null || $apcuEnabled === true) {
+                $loader->setApcuPrefix(getenv('BFR_API_CACHE_APCU_PREFIX') ?: 'bifrost_autoload');
+            }
+        }
         break;
     }
 }

--- a/api/Core/Settings.php
+++ b/api/Core/Settings.php
@@ -97,17 +97,19 @@ final class Settings
      */
     private static function iniSet(): void
     {
-        ini_set("display_errors", (bool) static::getEnv("BFR_API_DISPLAY_ERRORS") ?? false);
-        ini_set("display_startup_errors", (bool) static::getEnv("BFR_API_DISPLAY_ERRORS") ?? false);
+        $displayErrors = static::getEnv("BFR_API_DEBUG_SHOW_ERRORS") ?? false;
+        ini_set("display_errors", (bool) $displayErrors);
+        ini_set("display_startup_errors", (bool) $displayErrors);
+        static::configureApcu();
 
         if (session_status() === PHP_SESSION_ACTIVE) {
             return;
         }
 
-        ini_set('session.save_handler', static::getEnv("BFR_API_SESSION_SAVE_HANDLER") ?? "files");
-        ini_set('session.save_path', static::getEnv("BFR_API_SESSION_SAVE_PATH") ?? "/var/lib/php/sessions");
-        ini_set('session.gc_maxlifetime', static::getEnv("BFR_API_SESSION_GC_MAXLIFETIME") ?? 1440);
-        ini_set('session.cookie_lifetime', static::getEnv("BFR_API_SESSION_COOKIE_LIFETIME") ?? 0);
+        ini_set('session.save_handler', static::getEnv("BFR_API_SESSION_HANDLER") ?? "files");
+        ini_set('session.save_path', static::getEnv("BFR_API_SESSION_PATH") ?? "/var/lib/php/sessions");
+        ini_set('session.gc_maxlifetime', static::getEnv("BFR_API_SESSION_TTL") ?? 1440);
+        ini_set('session.cookie_lifetime', static::getEnv("BFR_API_SESSION_COOKIE_TTL") ?? 0);
     }
 
     /**
@@ -140,21 +142,45 @@ final class Settings
      */
     public function getSettingsDatabase(?string $databaseName = null): array
     {
-        $prefix = "BFR_API_";
+        $prefix = "BFR_API_DB_";
 
         if (!empty($databaseName)) {
             $databaseName = strtoupper($databaseName) . "_";
         }
 
-        $isNotSqlite = static::getEnv("{$prefix}{$databaseName}SQL_DRIVER", true) !== "sqlite";
+        $driver = static::getEnv("{$prefix}{$databaseName}DRIVER", true);
+        $isNotSqlite = $driver !== "sqlite";
 
         return [
-            "driver" => static::getEnv("{$prefix}{$databaseName}SQL_DRIVER", true),
-            "host" => static::getEnv("{$prefix}{$databaseName}SQL_HOST", $isNotSqlite),
-            "port" => static::getEnv("{$prefix}{$databaseName}SQL_PORT", $isNotSqlite),
-            "database" => static::getEnv("{$prefix}{$databaseName}SQL_DATABASE", true),
-            "username" => static::getEnv("{$prefix}{$databaseName}SQL_USER", $isNotSqlite),
-            "password" => static::getEnv("{$prefix}{$databaseName}SQL_PASSWORD", $isNotSqlite),
+            "driver" => $driver,
+            "host" => static::getEnv("{$prefix}{$databaseName}HOST", $isNotSqlite),
+            "port" => static::getEnv("{$prefix}{$databaseName}PORT", $isNotSqlite),
+            "database" => static::getEnv("{$prefix}{$databaseName}NAME", true),
+            "username" => static::getEnv("{$prefix}{$databaseName}USER", $isNotSqlite),
+            "password" => static::getEnv("{$prefix}{$databaseName}PASSWORD", $isNotSqlite),
         ];
+    }
+
+    /**
+     * Enables APCu when configured so runtime caches (including composer) benefit from it.
+     *
+     * @return void
+     */
+    private static function configureApcu(): void
+    {
+        $apcuEnabled = static::getEnv('BFR_API_CACHE_APCU_ENABLED');
+
+        if ($apcuEnabled === null || $apcuEnabled === '') {
+            return;
+        }
+
+        $enabled = filter_var($apcuEnabled, FILTER_VALIDATE_BOOL, FILTER_NULL_ON_FAILURE);
+
+        if ($enabled === false) {
+            return;
+        }
+
+        // These directives are CLI-safe and help when running tests or workers.
+        @ini_set('apc.enable_cli', '1');
     }
 }

--- a/api/Integration/Apcu.php
+++ b/api/Integration/Apcu.php
@@ -82,7 +82,7 @@ class Apcu
     private static function enabled(): bool
     {
         $settings = new Settings();
-        $enabled = $settings->BFR_API_APCU_ENABLED;
+        $enabled = $settings->BFR_API_CACHE_APCU_ENABLED;
 
         if ($enabled === null || $enabled === '') {
             return true;
@@ -94,7 +94,7 @@ class Apcu
     private static function defaultTtl(): int
     {
         $settings = new Settings();
-        $ttl = (int) ($settings->BFR_API_APCU_TTL ?? 3600);
+        $ttl = (int) ($settings->BFR_API_CACHE_APCU_TTL ?? 3600);
 
         return $ttl > 0 ? $ttl : 3600;
     }

--- a/api/Integration/Cache/RedisCache.php
+++ b/api/Integration/Cache/RedisCache.php
@@ -31,8 +31,16 @@ class RedisCache implements CacheInterface
     private static function conn(): void
     {
         $settings = new Settings();
-        $host = $settings->BFR_API_REDIS_HOST;
-        $port = $settings->BFR_API_REDIS_PORT;
+        $driver = strtolower($settings->BFR_API_CACHE_DRIVER ?? 'redis');
+
+        if ($driver !== 'redis') {
+            self::$enabled = false;
+            self::$redis = null;
+            return;
+        }
+
+        $host = $settings->BFR_API_CACHE_REDIS_HOST;
+        $port = $settings->BFR_API_CACHE_REDIS_PORT;
 
         if (empty($host) || empty($port)) {
             self::$enabled = false;

--- a/api/Integration/Queue/RedisQueue.php
+++ b/api/Integration/Queue/RedisQueue.php
@@ -17,7 +17,7 @@ class RedisQueue implements QueueInterface
     {
         if (empty(self::$redis)) {
             $settings = new Settings();
-            self::$queue = $settings->BFR_API_REDIS_QUEUE ?? 'bifrost_queue';
+            self::$queue = $settings->BFR_API_QUEUE_NAME ?? 'bifrost_queue';
             self::conn();
         }
     }
@@ -25,8 +25,8 @@ class RedisQueue implements QueueInterface
     private static function conn(): void
     {
         $settings = new Settings();
-        $host = $settings->BFR_API_REDIS_HOST;
-        $port = $settings->BFR_API_REDIS_PORT;
+        $host = $settings->BFR_API_QUEUE_REDIS_HOST;
+        $port = $settings->BFR_API_QUEUE_REDIS_PORT;
 
         if (empty($host) || empty($port)) {
             self::$enabled = false;
@@ -132,4 +132,3 @@ class RedisQueue implements QueueInterface
         self::$redis->lpush(self::$queue, serialize($task));
     }
 }
-

--- a/api/tests/Core/RequestTest.php
+++ b/api/tests/Core/RequestTest.php
@@ -142,7 +142,7 @@ final class RequestTest extends TestCase
 
     public function testRequestDoesNotCacheMetadataWhenApcuIsDisabled(): void
     {
-        putenv('BFR_API_APCU_ENABLED=0');
+        putenv('BFR_API_CACHE_APCU_ENABLED=0');
 
         $controller = new class implements Controller {
             #[Method('GET')]
@@ -162,7 +162,7 @@ final class RequestTest extends TestCase
 
         self::assertNull(Apcu::fetch($cacheKey));
 
-        putenv('BFR_API_APCU_ENABLED=1');
+        putenv('BFR_API_CACHE_APCU_ENABLED=1');
     }
 
     public function testHydrateAttributesKeepsOptionsWhenLoadedFromCache(): void

--- a/api/tests/Core/SettingsTest.php
+++ b/api/tests/Core/SettingsTest.php
@@ -10,13 +10,13 @@ final class SettingsTest extends TestCase
 {
     public function testReadsEnvironmentVariablesAndDatabaseSettings(): void
     {
-        putenv('BFR_API_SQL_DRIVER=sqlite');
-        putenv('BFR_API_SQL_DATABASE=' . bifrost_sqlite_path());
+        putenv('BFR_API_DB_DRIVER=sqlite');
+        putenv('BFR_API_DB_NAME=' . bifrost_sqlite_path());
 
         $settings = new Settings();
         $config = $settings->getSettingsDatabase();
 
-        self::assertSame('sqlite', $settings->BFR_API_SQL_DRIVER);
+        self::assertSame('sqlite', $settings->BFR_API_DB_DRIVER);
         self::assertSame('sqlite', $config['driver']);
         self::assertSame(bifrost_sqlite_path(), $config['database']);
         self::assertNull($config['host']);
@@ -24,7 +24,7 @@ final class SettingsTest extends TestCase
 
     public function testMissingRequiredEnvironmentVariableThrowsAppError(): void
     {
-        putenv('BFR_API_TEST_SQL_DRIVER');
+        putenv('BFR_API_TEST_DB_DRIVER');
 
         $settings = new Settings();
 

--- a/api/tests/bootstrap.php
+++ b/api/tests/bootstrap.php
@@ -14,20 +14,22 @@ use Bifrost\Core\Post;
 use Bifrost\Core\Session;
 use Bifrost\Integration\Database\PdoDatabase;
 
-putenv('BFR_API_DISPLAY_ERRORS=0');
-putenv('BFR_API_SESSION_SAVE_HANDLER=files');
-putenv('BFR_API_SESSION_SAVE_PATH=/tmp');
-putenv('BFR_API_SQL_DRIVER=sqlite');
-putenv('BFR_API_SQL_DATABASE=' . sys_get_temp_dir() . '/bifrost-api-phpunit.sqlite');
-putenv('BFR_API_SQL_USER');
-putenv('BFR_API_SQL_PASSWORD');
-putenv('BFR_API_SQL_HOST');
-putenv('BFR_API_SQL_PORT');
-putenv('BFR_API_REDIS_HOST');
-putenv('BFR_API_REDIS_PORT');
-putenv('BFR_API_APCU_ENABLED=1');
-putenv('BFR_API_APCU_TTL=3600');
-putenv('BFR_API_REDIS_QUEUE');
+putenv('BFR_API_DEBUG_SHOW_ERRORS=0');
+putenv('BFR_API_SESSION_HANDLER=files');
+putenv('BFR_API_SESSION_PATH=/tmp');
+putenv('BFR_API_DB_DRIVER=sqlite');
+putenv('BFR_API_DB_NAME=' . sys_get_temp_dir() . '/bifrost-api-phpunit.sqlite');
+putenv('BFR_API_DB_USER');
+putenv('BFR_API_DB_PASSWORD');
+putenv('BFR_API_DB_HOST');
+putenv('BFR_API_DB_PORT');
+putenv('BFR_API_CACHE_REDIS_HOST');
+putenv('BFR_API_CACHE_REDIS_PORT');
+putenv('BFR_API_CACHE_APCU_ENABLED=1');
+putenv('BFR_API_CACHE_APCU_TTL=3600');
+putenv('BFR_API_QUEUE_NAME');
+putenv('BFR_API_QUEUE_REDIS_HOST');
+putenv('BFR_API_QUEUE_REDIS_PORT');
 putenv('BFR_API_S3_BUCKET');
 putenv('BFR_API_S3_REGION');
 putenv('BFR_API_S3_KEY');
@@ -42,7 +44,7 @@ $_SESSION = [];
 
 function bifrost_sqlite_path(): string
 {
-    return (string) getenv('BFR_API_SQL_DATABASE');
+    return (string) getenv('BFR_API_DB_NAME');
 }
 
 function bifrost_reset_pdo_connections(): void


### PR DESCRIPTION
## Resumo
- remove chaves legadas de ambiente e adota apenas a nova conven e7 e3o BFR_API_* para cache, fila, DB, sess e3o e debug
- ativa APCu para autoloader/composer e ajusta configura e7 e3o de cache
- atualiza exemplos .env e ajustes de testes para refletir as vari e1veis novas

## Testes
- php -d date.timezone=UTC vendor/bin/phpunit --colors=never (no dev container 56bb57810af6)
