### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sync_labels.yml
+++ b/.github/workflows/sync_labels.yml
@@ -8,6 +8,9 @@ jobs:
 
   sync_labels:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/Felipe-Cavalca/Bifrost-API/security/code-scanning/1](https://github.com/Felipe-Cavalca/Bifrost-API/security/code-scanning/1)

To fix the problem, add an explicit `permissions` block that grants only the minimal scopes required by this workflow, instead of relying on the repository/organization defaults. This block can be defined at the workflow root (applies to all jobs) or at the job level (applies only to `sync_labels`). Since we only see one job, adding it to that job is straightforward and minimally intrusive.

The `sync_labels` job needs: (1) `contents: read` so `actions/checkout` can fetch the repository contents; and (2) `issues: write` so `micnncim/action-label-syncer@v1` can synchronize labels (labels are part of the issues/PR domain). It does not need broader write access like `contents: write`. So, in `.github/workflows/sync_labels.yml`, directly under `runs-on: ubuntu-latest`, insert a `permissions` block:

```yaml
    runs-on: ubuntu-latest
    permissions:
      contents: read
      issues: write
```

No imports or other definitions are needed since this is a YAML workflow file. This change does not alter the steps or behavior other than constraining the `GITHUB_TOKEN`’s capabilities for this job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
