### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish-docker-API.yml
+++ b/.github/workflows/publish-docker-API.yml
@@ -6,6 +6,9 @@ on:
 
 jobs:
   publish_docker_image_api:
+    permissions:
+      contents: read
+      packages: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout código


### PR DESCRIPTION
Potential fix for [https://github.com/Felipe-Cavalca/Bifrost-API/security/code-scanning/2](https://github.com/Felipe-Cavalca/Bifrost-API/security/code-scanning/2)

In general, to fix this class of issue you explicitly declare a `permissions` block either at the workflow root or on each job, granting only the scopes actually required. This prevents the `GITHUB_TOKEN` from inheriting broad default permissions and documents the workflow’s needs.

For this specific workflow, the only operations that use `GITHUB_TOKEN` are:
- `actions/checkout@v4`, which requires `contents: read`.
- `docker login ghcr.io` with `${{ secrets.GITHUB_TOKEN }}` to authenticate against GitHub Container Registry, which requires `packages: write` to push images.

The single best fix is to add a `permissions` block under the `publish_docker_image_api` job (or at the top level) with:
- `contents: read`
- `packages: write`

No other scopes such as `actions`, `pull-requests`, or `contents: write` are needed. We will modify `.github/workflows/publish-docker-API.yml` so that under `jobs:  publish_docker_image_api:` (before `runs-on:`) we add the `permissions` key with the two entries above. No imports or additional methods are required, since this is pure YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
