### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/merge_branch_on_release.yml
+++ b/.github/workflows/merge_branch_on_release.yml
@@ -1,4 +1,6 @@
 name: Update Release
+permissions:
+  contents: write
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/Felipe-Cavalca/Bifrost-API/security/code-scanning/3](https://github.com/Felipe-Cavalca/Bifrost-API/security/code-scanning/3)

In general, the fix is to define a `permissions` block that grants only the scopes needed by the job, instead of relying on default repository/organization permissions. For this workflow, the only privileged action is pushing to a branch, which requires `contents: write`. No other special scopes (issues, pull-requests, etc.) are needed based on the shown steps.

The best minimal fix without changing existing functionality is to add a root-level `permissions` block directly under the workflow `name:` (or equivalently under `on:`), so it applies to all jobs (there’s only one job here). This block should set `contents: write`, as the job must push to the repository, and omit all other scopes, leaving them at their default of `none`. Concretely, in `.github/workflows/merge_branch_on_release.yml`, add:

```yaml
permissions:
  contents: write
```

between the current line 2 (blank) and line 3 (`on:`). No imports or additional methods are needed, since this is purely a configuration change to the YAML workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
