### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tag_on_merge.yml
+++ b/.github/workflows/tag_on_merge.yml
@@ -1,11 +1,17 @@
 name: Tag on merge
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     types: [closed]
 
 jobs:
   create_tag_and_draft_release:
+    permissions:
+      contents: write
+      actions: write
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
     outputs:
@@ -90,6 +96,8 @@ jobs:
   update_release_draft:
     needs: create_tag_and_draft_release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: release-drafter/release-drafter@v6
         env:
@@ -98,6 +106,8 @@ jobs:
   publish_release:
     needs: [create_tag_and_draft_release, update_release_draft]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Publish Release
         uses: actions/github-script@v7
@@ -126,6 +136,8 @@ jobs:
     needs: publish_release
     if: contains(github.event.pull_request.labels.*.name, 'release')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/Felipe-Cavalca/Bifrost-API/security/code-scanning/4](https://github.com/Felipe-Cavalca/Bifrost-API/security/code-scanning/4)

In general, the fix is to add a `permissions` block either at the workflow root (applies to all jobs) or per job, granting only the scopes necessary for what each job does. This makes the workflow self-documenting and prevents it from inheriting broader defaults from the repo or organization.

For this workflow, the safest and clearest approach is to:

- Add a **top-level** `permissions` block with read-only repository access, which is a secure default for all jobs.
- Override that default for specific jobs that must write:
  - `create_tag_and_draft_release` needs to list tags, create git refs (tags), and fire `repository_dispatch` events, so it requires `contents: write` and `actions: write`.
  - `update_release_draft` uses `release-drafter`, which manages releases using `GITHUB_TOKEN`; this typically requires `contents: write`.
  - `publish_release` lists and updates releases, so it also needs `contents: write`.
  - `update_branch_release` checks out `main` and force-pushes `latest-release`, so it needs `contents: write`.

Concretely, in `.github/workflows/tag_on_merge.yml`:

1. Insert a root-level `permissions` block after the `name:` line, setting `contents: read` to establish a secure baseline.
2. Add a `permissions` block under each job that performs write operations, specifying only what that job needs:
   - For `create_tag_and_draft_release`, add `permissions: contents: write` and `actions: write`.
   - For `update_release_draft`, add `permissions: contents: write`.
   - For `publish_release`, add `permissions: contents: write`.
   - For `update_branch_release`, add `permissions: contents: write`.

No imports or external dependencies are required; this is purely declarative configuration in the workflow YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
