### PR TITLE
docs: padroniza ambiente e labels de PR

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,37 +1,158 @@
 ## Bifrost API settings
-#BFR_API_DEBUG_SHOW_ERRORS=1               # 1 para exibir erros (desenvolvimento), 0 para esconder (producao)
+##
+## Copie este arquivo para .env e altere somente o que for necessario para o
+## ambiente local, homologacao ou producao.
+##
+## Convencoes:
+## - Valores comentados indicam os defaults recomendados ou exemplos seguros.
+## - Nao commite .env com credenciais reais.
+## - Variaveis de segredo incluem senhas de banco e chaves de S3.
 
-# Sessao
-#BFR_API_SESSION_HANDLER=files             # files ou redis
+
+## ---------------------------------------------------------------------------
+## Runtime PHP e HTTP
+## ---------------------------------------------------------------------------
+
+## Exibe erros do PHP na resposta.
+## Use 1 apenas em desenvolvimento. Em producao, mantenha 0.
+#BFR_API_DEBUG_SHOW_ERRORS=0
+
+## Imagem usada pelo compose de producao da API.
+## Lida por api/Docker/docker-compose.prod.yml.
+#BFR_API_IMAGE=ghcr.io/felipe-cavalca/bifrost-api:latest
+
+## Porta HTTP exposta pelo Nginx no compose de producao.
+## Lida por api/Docker/docker-compose.prod.yml.
+#BFR_API_HTTP_PORT=80
+
+
+## ---------------------------------------------------------------------------
+## Sessao
+## ---------------------------------------------------------------------------
+
+## Handler de sessao do PHP.
+## Valores esperados: files ou redis.
+## O valor files grava sessoes no filesystem. O valor redis exige extensao
+## redis e session.save_path compativel com Redis.
+#BFR_API_SESSION_HANDLER=files
+
+## Caminho de persistencia da sessao.
+## Para files: use um diretorio gravavel pelo PHP.
+## Para redis: use um DSN aceito pelo handler redis, por exemplo:
+## tcp://redis:6379?prefix=bifrost_session:
 #BFR_API_SESSION_PATH=/var/lib/php/sessions
-#BFR_API_SESSION_TTL=1440                  # segundos para expirar a sessao
-#BFR_API_SESSION_COOKIE_TTL=0              # segundos do cookie; 0 = dura ate fechar o navegador
 
-# Cache
-#BFR_API_CACHE_DRIVER=apcu                 # apcu | redis | none
-#BFR_API_CACHE_APCU_ENABLED=1              # habilita APCu para metadados/autoloader
-#BFR_API_CACHE_APCU_TTL=3600               # TTL padrao em segundos para o APCu
+## Tempo maximo de vida da sessao no servidor, em segundos.
+#BFR_API_SESSION_TTL=1440
+
+## Tempo de vida do cookie de sessao, em segundos.
+## Use 0 para expirar ao fechar o navegador.
+#BFR_API_SESSION_COOKIE_TTL=0
+
+
+## ---------------------------------------------------------------------------
+## Cache
+## ---------------------------------------------------------------------------
+
+## Driver principal de cache da aplicacao.
+## Valores esperados: redis ou none.
+## Observacao: metadados internos e autoload podem usar APCu separadamente.
+#BFR_API_CACHE_DRIVER=redis
+
+## Habilita APCu para caches internos de runtime, como metadados de request e
+## prefixo do autoloader Composer.
+## Valores aceitos pelo PHP: 1/0, true/false, yes/no, on/off.
+#BFR_API_CACHE_APCU_ENABLED=1
+
+## Prefixo usado pelo autoloader Composer quando APCu estiver habilitado.
+## Ajuste quando mais de uma aplicacao compartilhar o mesmo processo/cache APCu.
+#BFR_API_CACHE_APCU_PREFIX=bifrost_autoload
+
+## TTL padrao, em segundos, para entradas armazenadas no APCu pelo framework.
+#BFR_API_CACHE_APCU_TTL=3600
+
+## Host do Redis usado pelo cache.
+## Se host ou porta estiverem vazios, o cache Redis fica desabilitado e o core
+## usa fallback seguro para leituras com valor padrao.
 #BFR_API_CACHE_REDIS_HOST=redis
-#BFR_API_CACHE_REDIS_PORT=6379
-#BFR_API_CACHE_QUERY_TTL=40                # TTL para caches de consultas
 
-# Fila
+## Porta do Redis usado pelo cache.
+#BFR_API_CACHE_REDIS_PORT=6379
+
+## TTL sugerido, em segundos, para caches de consultas.
+## Variavel reservada para padronizacao de projetos que usam o Bifrost.
+#BFR_API_CACHE_QUERY_TTL=40
+
+
+## ---------------------------------------------------------------------------
+## Fila
+## ---------------------------------------------------------------------------
+
+## Nome da fila Redis usada por Bifrost\Core\Queue.
 #BFR_API_QUEUE_NAME=bifrost_queue
+
+## Host do Redis usado pela fila.
+## Se host ou porta estiverem vazios, tarefas adicionadas pela fila podem ser
+## executadas imediatamente no processo atual, conforme implementacao atual.
 #BFR_API_QUEUE_REDIS_HOST=redis
+
+## Porta do Redis usado pela fila.
 #BFR_API_QUEUE_REDIS_PORT=6379
 
-# Banco de dados
-#BFR_API_DB_DRIVER=pgsql                   # sqlite | mysql | pgsql
+
+## ---------------------------------------------------------------------------
+## Banco de dados
+## ---------------------------------------------------------------------------
+
+## Driver de banco usado pela integracao PDO.
+## Valores esperados: sqlite, mysql ou pgsql.
+#BFR_API_DB_DRIVER=pgsql
+
+## Host do banco.
+## Obrigatorio para mysql e pgsql. Nao e necessario para sqlite.
 #BFR_API_DB_HOST=database
+
+## Porta do banco.
+## Obrigatorio para mysql e pgsql. Exemplos: 3306 para mysql, 5432 para pgsql.
 #BFR_API_DB_PORT=5432
+
+## Nome do banco.
+## Para sqlite, informe o caminho do arquivo .sqlite.
 #BFR_API_DB_NAME=bifrost
+
+## Usuario do banco.
+## Sensivel em ambientes reais. Obrigatorio para mysql e pgsql.
 #BFR_API_DB_USER=bifrost
+
+## Senha do banco.
+## Sensivel. Nao commite valores reais.
 #BFR_API_DB_PASSWORD=passwordBifrost
 
-# Storage S3 opcional
+
+## ---------------------------------------------------------------------------
+## Storage S3 opcional
+## ---------------------------------------------------------------------------
+
+## Bucket S3 usado por Bifrost\Integration\S3Storage.
 #BFR_API_S3_BUCKET=meu-bucket
+
+## Regiao do bucket S3.
+## Quando ausente, o codigo usa us-east-1.
 #BFR_API_S3_REGION=us-east-1
+
+## Access key S3.
+## Sensivel. Deixe vazio para usar credenciais resolvidas pelo SDK quando
+## o ambiente suportar IAM role, web identity ou provider equivalente.
 #BFR_API_S3_KEY=
+
+## Secret key S3.
+## Sensivel. Nao commite valores reais.
 #BFR_API_S3_SECRET=
-#BFR_API_S3_ENDPOINT=                      # exemplo: https://s3.sa-east-1.amazonaws.com
-#BFR_API_S3_PATH_STYLE=false               # true para forcar path-style
+
+## Endpoint customizado S3-compatible.
+## Use para MinIO, LocalStack ou provedores S3-compatible.
+#BFR_API_S3_ENDPOINT=
+
+## Forca path-style endpoint.
+## Use true para MinIO/LocalStack quando necessario.
+#BFR_API_S3_PATH_STYLE=false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,12 @@
 - Encapsule fornecedores externos atrás de interfaces ou adapters do projeto.
 - Use fakes nomeados em testes quando precisar substituir I/O externo.
 
+## Git e pull requests
+
+- PRs devem receber labels existentes em `.github/labels.yml`.
+- Antes de criar ou atualizar labels de um PR, consulte `.github/labels.yml` e use somente labels listadas nesse arquivo, salvo orientação explícita diferente.
+- As labels são usadas por workflows e automações; não deixe PR criado por agente sem label quando a ferramenta permitir aplicar labels.
+
 ## Verificações
 
 - API: execute `cd api && composer check`.

--- a/README.md
+++ b/README.md
@@ -144,36 +144,22 @@ curl "http://localhost/api/index/index"
 
 ## Variaveis de ambiente
 
-O projeto le as configuracoes principalmente via `api/Core/Settings.php` e pelas integracoes em `api/Integration/`.
+O projeto le as configuracoes principalmente via `api/Core/Settings.php`, pelas integracoes em `api/Integration/` e pelo compose de producao em `api/Docker/docker-compose.prod.yml`.
 
-Principais variaveis:
+O arquivo [`.env.example`](/workspaces/Bifrost-API/.env.example) documenta cada configuracao, valores esperados, defaults recomendados e variaveis sensiveis.
 
-| Nome | Uso |
-|------|-----|
-| `BFR_API_DISPLAY_ERRORS` | Liga ou desliga exibicao de erros do PHP |
-| `BFR_API_SESSION_SAVE_HANDLER` | Handler de sessao |
-| `BFR_API_SESSION_SAVE_PATH` | Local de persistencia de sessao |
-| `BFR_API_SESSION_GC_MAXLIFETIME` | TTL da sessao |
-| `BFR_API_SESSION_COOKIE_LIFETIME` | TTL do cookie de sessao |
-| `BFR_API_SQL_DRIVER` | Driver do banco: `sqlite`, `mysql` ou `pgsql` |
-| `BFR_API_SQL_HOST` | Host do banco |
-| `BFR_API_SQL_PORT` | Porta do banco |
-| `BFR_API_SQL_DATABASE` | Nome do banco ou path do arquivo SQLite |
-| `BFR_API_SQL_USER` | Usuario do banco |
-| `BFR_API_SQL_PASSWORD` | Senha do banco |
-| `BFR_API_REDIS_HOST` | Host do Redis |
-| `BFR_API_REDIS_PORT` | Porta do Redis |
-| `BFR_API_REDIS_QUEUE` | Nome da fila Redis |
-| `BFR_API_S3_BUCKET` | Bucket S3 |
-| `BFR_API_S3_REGION` | Regiao do bucket |
-| `BFR_API_S3_KEY` | Access key S3 |
-| `BFR_API_S3_SECRET` | Secret key S3 |
-| `BFR_API_S3_ENDPOINT` | Endpoint customizado de S3 |
-| `BFR_API_S3_PATH_STYLE` | Habilita path-style endpoint |
-| `BFR_API_IMAGE` | Imagem usada no compose de producao |
-| `BFR_API_HTTP_PORT` | Porta exposta pelo Nginx em producao |
+Principais grupos:
 
-O arquivo [`.env.example`](/workspaces/Bifrost-API/.env.example) tem um ponto de partida para configuracao local.
+| Grupo | Variaveis |
+|------|-----------|
+| Runtime | `BFR_API_DEBUG_SHOW_ERRORS`, `BFR_API_IMAGE`, `BFR_API_HTTP_PORT` |
+| Sessao | `BFR_API_SESSION_HANDLER`, `BFR_API_SESSION_PATH`, `BFR_API_SESSION_TTL`, `BFR_API_SESSION_COOKIE_TTL` |
+| Cache | `BFR_API_CACHE_DRIVER`, `BFR_API_CACHE_APCU_ENABLED`, `BFR_API_CACHE_APCU_PREFIX`, `BFR_API_CACHE_APCU_TTL`, `BFR_API_CACHE_REDIS_HOST`, `BFR_API_CACHE_REDIS_PORT`, `BFR_API_CACHE_QUERY_TTL` |
+| Fila | `BFR_API_QUEUE_NAME`, `BFR_API_QUEUE_REDIS_HOST`, `BFR_API_QUEUE_REDIS_PORT` |
+| Banco | `BFR_API_DB_DRIVER`, `BFR_API_DB_HOST`, `BFR_API_DB_PORT`, `BFR_API_DB_NAME`, `BFR_API_DB_USER`, `BFR_API_DB_PASSWORD` |
+| S3 | `BFR_API_S3_BUCKET`, `BFR_API_S3_REGION`, `BFR_API_S3_KEY`, `BFR_API_S3_SECRET`, `BFR_API_S3_ENDPOINT`, `BFR_API_S3_PATH_STYLE` |
+
+Variaveis sensiveis, como `BFR_API_DB_PASSWORD`, `BFR_API_S3_KEY` e `BFR_API_S3_SECRET`, nao devem ser commitadas com valores reais.
 
 ## Como funciona o request
 


### PR DESCRIPTION
## Objetivo

Padronizar a documentacao das variaveis de ambiente do framework e reforcar a regra local de labels para PRs.

## Principais mudancas

- Reorganiza o `.env.example` por grupos de configuracao.
- Explica finalidade, valores esperados e cuidados de cada variavel.
- Documenta `BFR_API_CACHE_APCU_PREFIX`, que ja era usada pelo autoload.
- Atualiza o `README.md` para remover nomes legados e apontar para os nomes atuais usados pelo codigo.
- Reforca no `AGENTS.md` local que PRs devem receber labels existentes em `.github/labels.yml`, pois automacoes dependem delas.

## Testes e verificacoes

- Verificada ausencia de referencias antigas como `BFR_API_SQL_*`, `BFR_API_REDIS_*` e `BFR_API_SESSION_SAVE_*` no README e no `.env.example`.
- Comparadas variaveis `BFR_API_*` usadas no codigo, README e workflows com as variaveis documentadas no `.env.example`.
- Conferido que o commit ficou com author e committer `ScriptPlayerAgent <scriptPlayerAgent@felipecavalca.dev>`.
- Testes automatizados nao foram executados porque a mudanca e apenas documental/configuracao de exemplo.

## Riscos ou pontos de atencao

- Nao altera `.env`, codigo PHP ou comportamento runtime.
- Variaveis sensiveis continuam documentadas sem valores reais.
- Labels aplicadas conforme `.github/labels.yml`: `documentation` e `IA`.