### PR TITLE
refactor: padroniza configuracao redis

### DIFF
--- a/api/Integration/Cache/RedisCache.php
+++ b/api/Integration/Cache/RedisCache.php
@@ -10,8 +10,8 @@
 namespace Bifrost\Integration\Cache;
 
 use Redis;
-use Bifrost\Core\Settings;
 use Bifrost\Interface\Cache as CacheInterface;
+use Bifrost\Integration\Redis\RedisConfig;
 
 /**
  * It is responsible for managing the cache.
@@ -30,19 +30,9 @@ class RedisCache implements CacheInterface
      */
     private static function conn(): void
     {
-        $settings = new Settings();
-        $driver = strtolower($settings->BFR_API_CACHE_DRIVER ?? 'redis');
+        $config = RedisConfig::forCache();
 
-        if ($driver !== 'redis') {
-            self::$enabled = false;
-            self::$redis = null;
-            return;
-        }
-
-        $host = $settings->BFR_API_CACHE_REDIS_HOST;
-        $port = $settings->BFR_API_CACHE_REDIS_PORT;
-
-        if (empty($host) || empty($port)) {
+        if (!$config->isEnabled()) {
             self::$enabled = false;
             self::$redis = null;
             return;
@@ -50,7 +40,7 @@ class RedisCache implements CacheInterface
 
         try {
             self::$redis = new Redis();
-            $connected = @self::$redis->connect($host, $port);
+            $connected = @self::$redis->connect($config->host(), $config->port());
             if (!$connected) {
                 self::$enabled = false;
                 self::$redis = null;

--- a/api/Integration/Queue/RedisQueue.php
+++ b/api/Integration/Queue/RedisQueue.php
@@ -2,9 +2,9 @@
 
 namespace Bifrost\Integration\Queue;
 
-use Bifrost\Core\Settings;
 use Bifrost\Interface\Queue as QueueInterface;
 use Bifrost\Interface\Task;
+use Bifrost\Integration\Redis\RedisConfig;
 use Redis;
 
 class RedisQueue implements QueueInterface
@@ -16,19 +16,15 @@ class RedisQueue implements QueueInterface
     public function __construct()
     {
         if (empty(self::$redis)) {
-            $settings = new Settings();
-            self::$queue = $settings->BFR_API_QUEUE_NAME ?? 'bifrost_queue';
-            self::conn();
+            self::conn(RedisConfig::forQueue());
         }
     }
 
-    private static function conn(): void
+    private static function conn(RedisConfig $config): void
     {
-        $settings = new Settings();
-        $host = $settings->BFR_API_QUEUE_REDIS_HOST;
-        $port = $settings->BFR_API_QUEUE_REDIS_PORT;
+        self::$queue = $config->queueName();
 
-        if (empty($host) || empty($port)) {
+        if (!$config->isEnabled()) {
             self::$enabled = false;
             self::$redis = null;
             return;
@@ -36,7 +32,7 @@ class RedisQueue implements QueueInterface
 
         try {
             self::$redis = new Redis();
-            $connected = @self::$redis->connect($host, $port);
+            $connected = @self::$redis->connect($config->host(), $config->port());
             if (!$connected) {
                 self::$enabled = false;
                 self::$redis = null;

--- a/api/Integration/Redis/RedisConfig.php
+++ b/api/Integration/Redis/RedisConfig.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bifrost\Integration\Redis;
+
+use Bifrost\Core\Settings;
+
+class RedisConfig
+{
+    public function __construct(
+        private readonly ?string $host,
+        private readonly ?int $port,
+        private readonly string $driver = 'redis',
+        private readonly string $queueName = 'bifrost_queue'
+    ) {
+    }
+
+    public static function forCache(?Settings $settings = null): self
+    {
+        $settings ??= new Settings();
+
+        return new self(
+            host: self::optionalString($settings->BFR_API_CACHE_REDIS_HOST),
+            port: self::optionalInt($settings->BFR_API_CACHE_REDIS_PORT),
+            driver: strtolower((string) ($settings->BFR_API_CACHE_DRIVER ?? 'redis'))
+        );
+    }
+
+    public static function forQueue(?Settings $settings = null): self
+    {
+        $settings ??= new Settings();
+
+        return new self(
+            host: self::optionalString($settings->BFR_API_QUEUE_REDIS_HOST),
+            port: self::optionalInt($settings->BFR_API_QUEUE_REDIS_PORT),
+            queueName: self::optionalString($settings->BFR_API_QUEUE_NAME) ?? 'bifrost_queue'
+        );
+    }
+
+    public function isRedisDriver(): bool
+    {
+        return $this->driver === 'redis';
+    }
+
+    public function isEnabled(): bool
+    {
+        return $this->isRedisDriver() && $this->host !== null && $this->port !== null;
+    }
+
+    public function host(): ?string
+    {
+        return $this->host;
+    }
+
+    public function port(): ?int
+    {
+        return $this->port;
+    }
+
+    public function queueName(): string
+    {
+        return $this->queueName;
+    }
+
+    private static function optionalString(mixed $value): ?string
+    {
+        if (!is_string($value)) {
+            return null;
+        }
+
+        $value = trim($value);
+
+        return $value === '' ? null : $value;
+    }
+
+    private static function optionalInt(mixed $value): ?int
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        return filter_var($value, FILTER_VALIDATE_INT) ?: null;
+    }
+}

--- a/api/tests/Integration/RedisConfigTest.php
+++ b/api/tests/Integration/RedisConfigTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+use Bifrost\Core\Settings;
+use Bifrost\Integration\Redis\RedisConfig;
+use PHPUnit\Framework\TestCase;
+
+final class RedisConfigTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        putenv('BFR_API_CACHE_DRIVER');
+        putenv('BFR_API_CACHE_REDIS_HOST');
+        putenv('BFR_API_CACHE_REDIS_PORT');
+        putenv('BFR_API_QUEUE_NAME');
+        putenv('BFR_API_QUEUE_REDIS_HOST');
+        putenv('BFR_API_QUEUE_REDIS_PORT');
+    }
+
+    public function testCacheConfigIsDisabledWhenDriverIsNone(): void
+    {
+        putenv('BFR_API_CACHE_DRIVER=none');
+        putenv('BFR_API_CACHE_REDIS_HOST=redis');
+        putenv('BFR_API_CACHE_REDIS_PORT=6379');
+
+        $config = RedisConfig::forCache(new Settings());
+
+        self::assertFalse($config->isEnabled());
+        self::assertFalse($config->isRedisDriver());
+    }
+
+    public function testCacheConfigReadsRedisConnection(): void
+    {
+        putenv('BFR_API_CACHE_DRIVER=redis');
+        putenv('BFR_API_CACHE_REDIS_HOST=redis');
+        putenv('BFR_API_CACHE_REDIS_PORT=6379');
+
+        $config = RedisConfig::forCache(new Settings());
+
+        self::assertTrue($config->isEnabled());
+        self::assertSame('redis', $config->host());
+        self::assertSame(6379, $config->port());
+    }
+
+    public function testQueueConfigKeepsDefaultQueueName(): void
+    {
+        putenv('BFR_API_QUEUE_REDIS_HOST');
+        putenv('BFR_API_QUEUE_REDIS_PORT');
+        putenv('BFR_API_QUEUE_NAME');
+
+        $config = RedisConfig::forQueue(new Settings());
+
+        self::assertFalse($config->isEnabled());
+        self::assertSame('bifrost_queue', $config->queueName());
+    }
+
+    public function testQueueConfigReadsConfiguredQueueName(): void
+    {
+        putenv('BFR_API_QUEUE_REDIS_HOST=redis');
+        putenv('BFR_API_QUEUE_REDIS_PORT=6379');
+        putenv('BFR_API_QUEUE_NAME=jobs');
+
+        $config = RedisConfig::forQueue(new Settings());
+
+        self::assertTrue($config->isEnabled());
+        self::assertSame('jobs', $config->queueName());
+    }
+}


### PR DESCRIPTION
## Objetivo

Padronizar a leitura de configuracao Redis usada por cache e fila sem alterar o contrato publico atual do framework.

## Principais mudancas

- Adiciona `Bifrost\Integration\Redis\RedisConfig` para centralizar host, porta, driver de cache e nome da fila.
- Atualiza `RedisCache` para usar o config object em vez de ler `Settings` diretamente.
- Atualiza `RedisQueue` para usar o mesmo padrao de configuracao.
- Mantem os mesmos nomes de variaveis de ambiente e o mesmo comportamento de fallback quando Redis nao esta configurado.
- Adiciona testes para configuracao de cache e fila.

## Testes executados

- `docker compose -f api\Docker\docker-compose.dev.yml run --rm api1 composer check`
- Resultado local: 88 testes, 261 assertions, 1 skip.

## Pontos de atencao

- Nao foi marcado como `upgrade` porque nao altera assinaturas publicas, defaults documentados, nomes de env nem comportamento esperado de fallback.
- `todo.md` local nao faz parte deste PR.