### PR TITLE
perf: reduz overhead do framework em rotas mapeadas

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 .github
 .vscode
 tests
+api/tests
 tmp
 api/tmp
 vendor

--- a/README.md
+++ b/README.md
@@ -95,12 +95,29 @@ docker compose -f api/Docker/docker-compose.dev.yml up -d --build
 
 O Nginx sobe na porta `80` e encaminha as requisicoes para dois workers PHP-FPM: `api1` e `api2`.
 
-Em producao, o compose usa a imagem definida em `BFR_API_IMAGE`:
+Em producao local, o compose builda a imagem `bifrost-api:prod-local` por padrao, usa `Dockerfile.prod` e sobe com configuracoes minimas de runtime. Logs estruturados e Redis de cache ficam desligados por padrao; sessao usa Redis local.
 
 ```bash
-BFR_API_IMAGE=ghcr.io/felipe-cavalca/bifrost-api:latest \
 docker compose -f api/Docker/docker-compose.prod.yml up -d
 ```
+
+Para usar outro nome/tag de imagem no build local, informe `BFR_API_IMAGE`.
+
+```bash
+BFR_API_IMAGE=bifrost-api:minha-tag \
+docker compose -f api/Docker/docker-compose.prod.yml up -d
+```
+
+No compose de producao, `GET /health`, `GET /index/health` e `GET /ping` passam pelo framework PHP. Para workloads de baixa latencia, como Rinha de Backend, prefira endpoints mapeados em `Bifrost\Enum\Routes`; esse caminho evita validacoes dinamicas de controller/action sem remover suporte a attributes, observabilidade e respostas HTTP quando usados.
+
+O compose prod local fica dentro de 1 CPU e 350 MB somados por padrao:
+
+- `nginx`: 0.08 CPU e 38 MB.
+- `api1`: 0.455 CPU e 140 MB.
+- `api2`: 0.455 CPU e 140 MB.
+- `redis`: 0.01 CPU e 32 MB.
+
+Para medir o menor overhead do framework, use `GET /ping` com `BFR_API_LOG_DRIVER=none`.
 
 ### Sem Docker
 

--- a/api/Class/TextResponse.php
+++ b/api/Class/TextResponse.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Bifrost\Class;
+
+use Bifrost\Interface\Responseable;
+
+class TextResponse implements Responseable
+{
+    public function __construct(
+        private readonly string $text
+    ) {
+    }
+
+    public function jsonSerialize(): string
+    {
+        return $this->text;
+    }
+}

--- a/api/Controller/index.php
+++ b/api/Controller/index.php
@@ -3,6 +3,7 @@
 namespace Bifrost\Controller;
 
 use Bifrost\Class\HttpResponse;
+use Bifrost\Class\TextResponse;
 use Bifrost\Interface\Controller;
 use Bifrost\Interface\Responseable;
 
@@ -24,5 +25,10 @@ class Index implements Controller
                 'checked_at' => gmdate('c'),
             ]
         );
+    }
+
+    public function ping(): Responseable
+    {
+        return new TextResponse('pong');
     }
 }

--- a/api/Core/Autoload.php
+++ b/api/Core/Autoload.php
@@ -34,9 +34,16 @@ spl_autoload_register(
             $className = substr($className, strlen($prefix));
         }
 
-        $file = __DIR__ . DIRECTORY_SEPARATOR . ".." . DIRECTORY_SEPARATOR . str_replace("\\", DIRECTORY_SEPARATOR, $className) . ".php";
+        $relativeFile = str_replace("\\", DIRECTORY_SEPARATOR, $className) . ".php";
+        $file = __DIR__ . DIRECTORY_SEPARATOR . ".." . DIRECTORY_SEPARATOR . $relativeFile;
         if (is_readable($file)) {
             require_once $file;
+            return true;
+        }
+
+        $lowercaseFile = dirname($file) . DIRECTORY_SEPARATOR . lcfirst(basename($file));
+        if (is_readable($lowercaseFile)) {
+            require_once $lowercaseFile;
         }
 
         return true;

--- a/api/Core/Get.php
+++ b/api/Core/Get.php
@@ -6,41 +6,36 @@ use Bifrost\Enum\Routes;
 
 class Get
 {
-    private static array $data;
+    private static array $data = [];
     public static string $controller;
     public static string $action;
+    public static bool $routeMapped = false;
 
     public function __construct()
     {
-        if (! $_GET instanceof Get) {
-
-            // Define o controlador e a ação padrão
-            $path = $_GET["_controller"] ?? "index";
-            $action = empty($_GET["_action"]) ? "index" : $_GET["_action"];
-
-            // Verifica se está nas rotas mapeadas
-            $route = Routes::fromRequest($path);
-
-            if ($route) {
-                // Divide "Controller/action"
-                [$controller, $action] = explode("/", $route->value);
-            } else {
-                $controller = $path;
-            }
-
-            // setando o controller e a ação
-            self::$controller = $controller;
-            self::$action = $action;
-
-            // Remove os parâmetros de controle e ação do array $_GET
-            unset($_GET["_controller"], $_GET["_action"]);
-
-            // Armazena os dados restantes em uma propriedade estática
-            self::$data = $_GET;
-
-            // Define $_GET como uma instância desta classe
-            $_GET = $this;
+        if ($_GET instanceof Get) {
+            return;
         }
+
+        $data = $_GET;
+        $path = $data["_controller"] ?? "index";
+        $action = empty($data["_action"]) ? "index" : $data["_action"];
+        $route = Routes::fromRequest((string) $path);
+        self::$routeMapped = $route !== null;
+
+        if ($route) {
+            [$controller, $action] = explode("/", $route->value);
+        } else {
+            $controller = (string) $path;
+        }
+
+        self::$controller = $controller;
+        self::$action = (string) $action;
+
+        unset($data["_controller"], $data["_action"]);
+
+        self::$data = $data;
+        $_GET = $this;
     }
 
     public function __toString()
@@ -58,6 +53,8 @@ class Get
                 return self::$controller;
             case "action":
                 return self::$action;
+            case "routeMapped":
+                return self::$routeMapped;
             default:
                 return self::$data[$name] ?? null;
         }

--- a/api/Core/Logger.php
+++ b/api/Core/Logger.php
@@ -10,6 +10,8 @@ final class Logger
 {
     private static ?UUID $requestId = null;
     private static ?NoSqlDatabase $noSqlDatabase = null;
+    private static ?string $driver = null;
+    private static string|false|null $driverEnv = null;
 
     public static function debug(string $message, array $context = []): void
     {
@@ -53,6 +55,8 @@ final class Logger
     public static function resetRequestId(?UUID $requestId = null): void
     {
         self::$requestId = $requestId;
+        self::$driver = null;
+        self::$driverEnv = null;
     }
 
     public static function setNoSqlDatabase(?NoSqlDatabase $noSqlDatabase): void
@@ -69,19 +73,21 @@ final class Logger
 
     public static function isDisabled(?Settings $settings = null): bool
     {
-        $settings ??= new Settings();
+        return !self::isEnabled($settings);
+    }
 
-        return strtolower((string) $settings->BFR_API_LOG_DRIVER) === 'none';
+    public static function isEnabled(?Settings $settings = null): bool
+    {
+        return self::driver($settings) !== 'none';
     }
 
     private static function write(string $level, string $message, array $context): void
     {
-        $settings = new Settings();
-
-        if (self::isDisabled(settings: $settings)) {
+        if (!self::isEnabled()) {
             return;
         }
 
+        $settings = new Settings();
         $driver = self::driver($settings);
 
         $entry = [
@@ -126,9 +132,19 @@ final class Logger
         }
     }
 
-    private static function driver(Settings $settings): string
+    private static function driver(?Settings $settings = null): string
     {
-        return strtolower((string) ($settings->BFR_API_LOG_DRIVER ?? 'error_log'));
+        $driver = $settings !== null
+            ? (string) ($settings->BFR_API_LOG_DRIVER ?? 'error_log')
+            : (getenv('BFR_API_LOG_DRIVER') ?: 'error_log');
+
+        if (self::$driver !== null && self::$driverEnv === $driver) {
+            return self::$driver;
+        }
+
+        self::$driverEnv = $driver;
+
+        return self::$driver = strtolower((string) $driver);
     }
 
     private static function mongoCollection(Settings $settings): string

--- a/api/Core/Request.php
+++ b/api/Core/Request.php
@@ -36,17 +36,26 @@ final class Request
     private const JSON_RESPONSE_OPTIONS = JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE;
 
     private Get $Get;
+    private string $controller;
+    private string $action;
+    private bool $routeMapped;
+    private static array $controllerExistsCache = [];
+    private static array $actionExistsCache = [];
+    private static array $attributesMetadataCache = [];
 
     public function __construct()
     {
         $this->Get = new Get();
+        $this->controller = Get::$controller;
+        $this->action = Get::$action;
+        $this->routeMapped = Get::$routeMapped;
         Settings::init();
         Logger::sendRequestIdHeader();
     }
 
     public function __toString(): string
     {
-        return $this->handleResponse($this->run($this->Get->controller, $this->Get->action));
+        return $this->handleResponse($this->run($this->controller, $this->action, $this->routeMapped));
     }
 
     /**
@@ -55,31 +64,33 @@ final class Request
      * @param string $action Nome da ação do Controller.
      * @return mixed Retorna o resultado da ação do Controller.
      */
-    public static function run(string|Controller $controller, string $action): Responseable
+    public static function run(string|Controller $controller, string $action, bool $trustedRoute = false): Responseable
     {
         $attributes = [];
         $response = null;
+        $loggerEnabled = Logger::isEnabled();
 
-        Logger::info('Request started', [
-            'controller' => is_string($controller) ? $controller : $controller::class,
-            'action' => $action,
-            'method' => $_SERVER['REQUEST_METHOD'] ?? null,
-            'path' => parse_url((string) ($_SERVER['REQUEST_URI'] ?? ''), PHP_URL_PATH) ?: null,
-        ]);
+        if ($loggerEnabled) {
+            Logger::info('Request started', [
+                'controller' => is_string($controller) ? $controller : $controller::class,
+                'action' => $action,
+                'method' => $_SERVER['REQUEST_METHOD'] ?? null,
+                'path' => parse_url((string) ($_SERVER['REQUEST_URI'] ?? ''), PHP_URL_PATH) ?: null,
+            ]);
+        }
 
         try {
-            if (is_string($controller) && (empty($controller) || !self::validateControllerName($controller))) {
+            if (!$trustedRoute && is_string($controller) && (empty($controller) || !self::validateControllerName($controller))) {
                 throw new AppError(HttpResponse::notFound(["controller" => $controller], "Controller not found"));
             }
 
             $objController = self::resolveController($controller);
 
-            if (!self::validateActionName($objController, $action)) {
+            if (!$trustedRoute && !self::validateActionName($objController, $action)) {
                 throw new AppError(HttpResponse::notFound(["action" => $action], "Action not found"));
             }
 
-            $reflectionMethod = new ReflectionMethod($objController, $action);
-            $attributes = self::getAttributes($reflectionMethod);
+            $attributes = self::getAttributes($objController, $action);
             $return = self::runBeforeAttributes($attributes);
 
             // Se o método beforeRun retornar algo, não executa a ação do controller.
@@ -87,10 +98,12 @@ final class Request
                 $response = $return;
             } else {
                 $response = self::runAction($objController, $action);
-                Logger::info('Request finished', [
-                    'controller' => $objController::class,
-                    'action' => $action,
-                ]);
+                if ($loggerEnabled) {
+                    Logger::info('Request finished', [
+                        'controller' => $objController::class,
+                        'action' => $action,
+                    ]);
+                }
             }
         } catch (\Throwable $erro) {
             if ($erro instanceof AppError) {
@@ -114,7 +127,7 @@ final class Request
             $response = HttpResponse::internalServerError([], 'After attribute failed');
         }
 
-        if ($response instanceof HttpResponse && !Logger::isDisabled()) {
+        if ($response instanceof HttpResponse && $loggerEnabled) {
             $response->addRequestId(Logger::requestId());
         }
 
@@ -128,18 +141,22 @@ final class Request
      */
     private static function validateControllerName(string $controller): bool
     {
+        if (array_key_exists($controller, self::$controllerExistsCache)) {
+            return self::$controllerExistsCache[$controller];
+        }
+
         $cacheKey = self::getCacheKey('controller_exists', $controller);
         $cached = Apcu::fetch($cacheKey);
         if (is_bool($cached)) {
-            return $cached;
+            return self::$controllerExistsCache[$controller] = $cached;
         }
 
         $nameController = Path::FOLDER->toDirectory() . Path::CONTROLLERS->toDirectory() . $controller . ".php";
-        $controllerClass = Path::NAMESPACE->value . Path::CONTROLLERS->value . $controller;
+        $controllerClass = self::controllerClass($controller);
         $exists = is_readable($nameController) && class_exists($controllerClass);
 
         Apcu::store($cacheKey, $exists);
-        return $exists;
+        return self::$controllerExistsCache[$controller] = $exists;
     }
 
     /**
@@ -149,7 +166,7 @@ final class Request
      */
     private static function loadController(string $controllerName): Controller
     {
-        $controller = Path::NAMESPACE->value . Path::CONTROLLERS->value . $controllerName;
+        $controller = self::controllerClass($controllerName);
         return new $controller();
     }
 
@@ -161,15 +178,21 @@ final class Request
      */
     private static function validateActionName(Controller $controller, string $action): bool
     {
-        $cacheKey = self::getCacheKey('action_exists', $controller::class, $action);
+        $controllerClass = $controller::class;
+        $localCacheKey = $controllerClass . '::' . $action;
+        if (array_key_exists($localCacheKey, self::$actionExistsCache)) {
+            return self::$actionExistsCache[$localCacheKey];
+        }
+
+        $cacheKey = self::getCacheKey('action_exists', $controllerClass, $action);
         $cached = Apcu::fetch($cacheKey);
         if (is_bool($cached)) {
-            return $cached;
+            return self::$actionExistsCache[$localCacheKey] = $cached;
         }
 
         $exists = method_exists($controller, $action);
         Apcu::store($cacheKey, $exists);
-        return $exists;
+        return self::$actionExistsCache[$localCacheKey] = $exists;
     }
 
     /**
@@ -177,18 +200,26 @@ final class Request
      * @param ReflectionMethod $reflectionMethod Método a ser analisado.
      * @return array Retorna um array com os atributos do método.
      */
-    private static function getAttributes(ReflectionMethod $reflectionMethod): array
+    private static function getAttributes(Controller $controller, string $action): array
     {
+        $controllerClass = $controller::class;
         $cacheKey = self::getCacheKey(
             'method_attributes',
-            $reflectionMethod->getDeclaringClass()->getName(),
-            $reflectionMethod->getName()
+            $controllerClass,
+            $action
         );
+
+        if (array_key_exists($cacheKey, self::$attributesMetadataCache)) {
+            return self::hydrateAttributes(self::$attributesMetadataCache[$cacheKey]);
+        }
+
         $cached = Apcu::fetch($cacheKey);
         if (is_array($cached)) {
+            self::$attributesMetadataCache[$cacheKey] = $cached;
             return self::hydrateAttributes($cached);
         }
 
+        $reflectionMethod = new ReflectionMethod($controller, $action);
         $attributesReturn = [];
         $attributesMetadata = [];
         $attributes = $reflectionMethod->getAttributes();
@@ -200,6 +231,7 @@ final class Request
             $attributesReturn[] = $attribute->newInstance();
         }
 
+        self::$attributesMetadataCache[$cacheKey] = $attributesMetadata;
         Apcu::store($cacheKey, $attributesMetadata);
         return $attributesReturn;
     }
@@ -211,6 +243,10 @@ final class Request
      */
     private static function runBeforeAttributes(array $attributes): null|Responseable
     {
+        if ($attributes === []) {
+            return null;
+        }
+
         foreach ($attributes as $attribute) {
             if ($attribute instanceof AttributeBefore) {
                 $retorno = $attribute->before();
@@ -230,6 +266,10 @@ final class Request
      */
     private static function runAfterAttributes(array $attributes, Responseable $return): null|\Throwable
     {
+        if ($attributes === []) {
+            return null;
+        }
+
         foreach ($attributes as $attribute) {
             if ($attribute instanceof AttributeAfter) {
                 try {
@@ -250,7 +290,7 @@ final class Request
      */
     private static function runAction(Controller $controller, string $action): Responseable
     {
-        return call_user_func([$controller, $action]);
+        return $controller->{$action}();
     }
 
     /**
@@ -276,7 +316,7 @@ final class Request
     public static function getOptionsAttributes(string|Controller $controller, string $action): array
     {
         $controller = self::resolveController($controller);
-        $attributes = self::getAttributes(new ReflectionMethod($controller, $action));
+        $attributes = self::getAttributes($controller, $action);
         $options = [];
         foreach ($attributes as $attribute) {
             if ($attribute instanceof Attribute) {
@@ -312,4 +352,8 @@ final class Request
         return Cache::buildKey('request', ...$parts);
     }
 
+    private static function controllerClass(string $controller): string
+    {
+        return Path::NAMESPACE->value . Path::CONTROLLERS->value . ucfirst($controller);
+    }
 }

--- a/api/Docker/Dockerfile.prod
+++ b/api/Docker/Dockerfile.prod
@@ -24,6 +24,7 @@ RUN apt-get update \
 # Copiando os arquivos da aplicacao (build context: raiz do repositorio)
 COPY api/composer.json /var/www/html/composer.json
 COPY api/ /var/www/html/
+COPY api/Docker/php-fpm.prod.conf /usr/local/etc/php-fpm.d/zz-bifrost-prod.conf
 
 # Instala dependencias PHP (inclui autoload do Composer para integracoes opcionais)
 RUN composer install --no-dev --prefer-dist --no-interaction --optimize-autoloader

--- a/api/Docker/docker-compose.prod.yml
+++ b/api/Docker/docker-compose.prod.yml
@@ -2,26 +2,54 @@ name: bifrost-api
 
 x-template-api:
   template-api: &template-api
-    image: ${BFR_API_IMAGE:-ghcr.io/felipe-cavalca/bifrost-api:latest}
-    pull_policy: always
+    image: ${BFR_API_IMAGE:-bifrost-api:prod-local}
+    build:
+      context: ../..
+      dockerfile: api/Docker/Dockerfile.prod
+    pull_policy: never
+    command: ["/usr/local/sbin/php-fpm", "-F"]
     env_file:
-      - ./../../.env
+      - path: ./../../.env
+        required: false
+    environment:
+      BFR_API_DEBUG_SHOW_ERRORS: ${BFR_API_DEBUG_SHOW_ERRORS:-0}
+      BFR_API_LOG_DRIVER: ${BFR_API_LOG_DRIVER:-none}
+      BFR_API_CACHE_DRIVER: ${BFR_API_CACHE_DRIVER:-none}
+      BFR_API_CACHE_APCU_ENABLED: ${BFR_API_CACHE_APCU_ENABLED:-1}
+      BFR_API_CACHE_APCU_PREFIX: ${BFR_API_CACHE_APCU_PREFIX:-bifrost_prod_local}
+      BFR_API_SESSION_HANDLER: ${BFR_API_SESSION_HANDLER:-redis}
+      BFR_API_SESSION_PATH: ${BFR_API_SESSION_PATH:-tcp://redis:6379?prefix=bifrost_session:}
+      BFR_API_SESSION_TTL: ${BFR_API_SESSION_TTL:-1440}
+      BFR_API_SESSION_COOKIE_TTL: ${BFR_API_SESSION_COOKIE_TTL:-0}
+      BFR_API_STORAGE_DRIVER: ${BFR_API_STORAGE_DRIVER:-local}
+      BFR_API_STORAGE_LOCAL_PATH: ${BFR_API_STORAGE_LOCAL_PATH:-/var/www/html/tmp/storage}
     networks:
       - bifrost-back-network
     restart: unless-stopped
-    # mem_limit: 256m
-    # cpus: '0.25'
+    mem_limit: 140m
+    cpus: '0.455'
 
 services:
+  redis:
+    image: redis:7-alpine
+    command: redis-server --save "" --appendonly no
+    mem_limit: 32m
+    cpus: '0.01'
+    networks:
+      - bifrost-back-network
+    restart: unless-stopped
+
   nginx:
     image: nginx:alpine
+    mem_limit: 38m
+    cpus: '0.08'
     ports:
       - "${BFR_API_HTTP_PORT:-80}:80"
     depends_on:
       - api1
       - api2
     volumes:
-      - ../nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./nginx.prod.conf:/etc/nginx/nginx.conf:ro
     networks:
       - bifrost-back-network
     restart: unless-stopped
@@ -29,10 +57,14 @@ services:
   api1:
     <<: *template-api
     container_name: api1
+    depends_on:
+      - redis
 
   api2:
     <<: *template-api
     container_name: api2
+    depends_on:
+      - redis
 
 networks:
   bifrost-back-network:

--- a/api/Docker/nginx.prod.conf
+++ b/api/Docker/nginx.prod.conf
@@ -1,0 +1,44 @@
+worker_processes 1;
+
+events {
+    worker_connections 4096;
+}
+
+http {
+    access_log off;
+    sendfile on;
+    tcp_nopush on;
+    tcp_nodelay on;
+    keepalive_timeout 30;
+
+    upstream api_backend {
+        keepalive 32;
+        server api1:9000;
+        server api2:9000;
+    }
+
+    server {
+        listen 80;
+        root /var/www/html;
+        index index.php;
+
+        add_header Access-Control-Allow-Origin *;
+
+        location / {
+            try_files $uri @api_rewrite;
+        }
+
+        location @api_rewrite {
+            rewrite ^/([^/]+)/?([^/]*)/?(.*)$ /index.php?_controller=$1&_action=$2&_params=$3&$args last;
+            rewrite ^ /index.php$is_args$args last;
+        }
+
+        location ~ \.php$ {
+            fastcgi_pass api_backend;
+            fastcgi_index index.php;
+            include fastcgi_params;
+            fastcgi_param SCRIPT_FILENAME /var/www/html$fastcgi_script_name;
+            fastcgi_keep_conn on;
+        }
+    }
+}

--- a/api/Docker/php-fpm.prod.conf
+++ b/api/Docker/php-fpm.prod.conf
@@ -1,0 +1,10 @@
+[www]
+access.log = /dev/null
+pm = static
+pm.max_children = 2
+pm.max_requests = 0
+listen.backlog = 1024
+clear_env = no
+
+[global]
+log_level = warning

--- a/api/Enum/Routes.php
+++ b/api/Enum/Routes.php
@@ -4,43 +4,41 @@ namespace Bifrost\Enum;
 
 Enum Routes: string
 {
-
     /**
-     * Enumeração de rotas do sistema.
-     * Cada rota é definida como um caso do enum, representando o caminho da rota.
+     * Enumeracao de rotas do sistema.
+     * Cada rota e definida como um caso do enum, representando o caminho da rota.
      */
     case login = "auth/login";
     case logout = "auth/logout";
     case health = "index/health";
+    case ping = "index/ping";
 
     /**
-     * Converte o caminho da requisição para o formato de enumeração.
-     * @param string $path O caminho da requisição, como "payments-sumary".
-     * @return self|null Retorna a enumeração correspondente ou null se não encontrado.
+     * Converte o caminho da requisicao para o formato de enumeracao.
+     * @param string $path O caminho da requisicao, como "payments-sumary".
+     * @return self|null Retorna a enumeracao correspondente ou null se nao encontrado.
      */
     public static function fromRequest(string $path): ?self
     {
+        static $routesByName = null;
+
+        if ($routesByName === null) {
+            $routesByName = [];
+            foreach (self::cases() as $route) {
+                $routesByName[$route->name] = $route;
+            }
+        }
+
+        if (isset($routesByName[$path])) {
+            return $routesByName[$path];
+        }
+
         $converted = preg_replace_callback(
             '/[-\/](\w)/',
             fn($m) => strtoupper($m[1]),
             $path
         );
 
-        return self::tryFromName($converted);
-    }
-
-    /**
-     * Tenta encontrar uma enumeração pelo nome.
-     * @param string $name O nome da enumeração, como "paymentsSummary".
-     * @return self|null Retorna a enumeração correspondente ou null se não encontrado.
-     */
-    private static function tryFromName(string $name): ?self
-    {
-        foreach (self::cases() as $route) {
-            if ($route->name === $name) {
-                return $route;
-            }
-        }
-        return null;
+        return is_string($converted) ? ($routesByName[$converted] ?? null) : null;
     }
 }

--- a/api/Integration/Apcu.php
+++ b/api/Integration/Apcu.php
@@ -2,11 +2,13 @@
 
 namespace Bifrost\Integration;
 
-use Bifrost\Core\Settings;
-
 class Apcu
 {
     private static array $fallback = [];
+    private static ?bool $enabled = null;
+    private static string|false|null $enabledEnv = null;
+    private static ?int $ttl = null;
+    private static string|false|null $ttlEnv = null;
 
     public static function store(string $key, mixed $value, ?int $ttl = null): bool
     {
@@ -81,21 +83,32 @@ class Apcu
 
     private static function enabled(): bool
     {
-        $settings = new Settings();
-        $enabled = $settings->BFR_API_CACHE_APCU_ENABLED;
+        $enabled = getenv('BFR_API_CACHE_APCU_ENABLED');
 
-        if ($enabled === null || $enabled === '') {
-            return true;
+        if (self::$enabled !== null && self::$enabledEnv === $enabled) {
+            return self::$enabled;
         }
 
-        return filter_var($enabled, FILTER_VALIDATE_BOOL, FILTER_NULL_ON_FAILURE) ?? true;
+        self::$enabledEnv = $enabled;
+
+        if ($enabled === false || $enabled === '') {
+            return self::$enabled = true;
+        }
+
+        return self::$enabled = filter_var($enabled, FILTER_VALIDATE_BOOL, FILTER_NULL_ON_FAILURE) ?? true;
     }
 
     private static function defaultTtl(): int
     {
-        $settings = new Settings();
-        $ttl = (int) ($settings->BFR_API_CACHE_APCU_TTL ?? 3600);
+        $ttlEnv = getenv('BFR_API_CACHE_APCU_TTL');
 
-        return $ttl > 0 ? $ttl : 3600;
+        if (self::$ttl !== null && self::$ttlEnv === $ttlEnv) {
+            return self::$ttl;
+        }
+
+        self::$ttlEnv = $ttlEnv;
+        $ttl = (int) ($ttlEnv ?: 3600);
+
+        return self::$ttl = $ttl > 0 ? $ttl : 3600;
     }
 }

--- a/api/composer.json
+++ b/api/composer.json
@@ -10,8 +10,15 @@
   },
   "autoload": {
     "psr-4": {
-      "Bifrost\\\\": "./"
-    }
+      "Bifrost\\": "./"
+    },
+    "classmap": [
+      "Controller/index.php",
+      "DataTypes/base64.php",
+      "DataTypes/filePath.php",
+      "DataTypes/url.php",
+      "Interface/PdoDriverAdapter.php"
+    ]
   },
   "scripts": {
     "analyse": "phpstan analyse --configuration=phpstan.neon",

--- a/api/tests/Class/TextResponseTest.php
+++ b/api/tests/Class/TextResponseTest.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use Bifrost\Class\TextResponse;
+use PHPUnit\Framework\TestCase;
+
+final class TextResponseTest extends TestCase
+{
+    public function testTextResponseSerializesText(): void
+    {
+        self::assertSame('pong', (new TextResponse('pong'))->jsonSerialize());
+    }
+}

--- a/api/tests/Core/GetRouteMappedTest.php
+++ b/api/tests/Core/GetRouteMappedTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Bifrost\Core\Get;
+use PHPUnit\Framework\TestCase;
+
+final class GetRouteMappedTest extends TestCase
+{
+    public function testMarksMappedRoute(): void
+    {
+        bifrost_reset_get(['_controller' => 'ping']);
+
+        self::assertTrue(Get::$routeMapped);
+    }
+
+    public function testMarksUnmappedRoute(): void
+    {
+        bifrost_reset_get(['_controller' => 'index', '_action' => 'health']);
+
+        self::assertFalse(Get::$routeMapped);
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -67,6 +67,7 @@ Regras:
 - Validacoes transversais devem ficar em attributes, DataTypes ou objetos dedicados.
 - Respostas HTTP devem usar `HttpResponse` ou outro `Responseable`.
 - O ciclo de request deve preservar compatibilidade com attributes `before` e `after`.
+- Rotas mapeadas em `Bifrost\Enum\Routes` podem usar o caminho rapido do core: o framework trata controller/action como confiaveis e evita validacoes dinamicas redundantes. Rotas livres continuam validando controller/action em tempo de execucao.
 
 ### Core
 


### PR DESCRIPTION
## Objetivo

Reduzir o overhead do framework em endpoints simples e em workloads de baixa latencia, mantendo compatibilidade com observabilidade, attributes, validacoes e contratos publicos.

## Principais mudancas

- Adiciona caminho rapido para rotas mapeadas em `Bifrost\Enum\Routes`, evitando validacoes dinamicas redundantes de controller/action.
- Otimiza `Request`, `Logger` e `Apcu` para reduzir custo quando logs/cache estao no caminho quente.
- Corrige o prefixo PSR-4 do Composer e adiciona classmap para arquivos legados.
- Adiciona `TextResponse` e endpoint `GET /ping` para medir o menor overhead do framework.
- Ajusta compose prod local, Nginx e PHP-FPM para perfil com 1 CPU e 350 MB.
- Exclui testes do build Docker prod via `.dockerignore`.
- Documenta o caminho recomendado para workloads tipo Rinha.

## Testes executados

- `docker compose -f api\Docker\docker-compose.dev.yml run --rm api1 composer validate --strict`
- `docker compose -f api\Docker\docker-compose.dev.yml run --rm api1 vendor/bin/php-cs-fixer fix --dry-run --diff --config=.php-cs-fixer.dist.php Core/Autoload.php Core/Get.php Core/Logger.php Core/Request.php Enum/Routes.php Integration/Apcu.php Class/TextResponse.php tests/Class/TextResponseTest.php tests/Core/GetRouteMappedTest.php`
- `docker compose -f api\Docker\docker-compose.dev.yml run --rm api1 vendor/bin/phpstan analyse --configuration=phpstan.neon`
- `docker compose -f api\Docker\docker-compose.dev.yml run --rm api1 vendor/bin/phpunit -c phpunit.xml`

## Pontos de atencao

- A suite completa passou com 1 teste skipped por dependencia externa.
- `composer check` completo ainda pode apontar formatacao de arquivos legados fora do escopo por final de linha.
- `todo.md` ficou fora do commit.

## Issues relacionadas

- Relacionado a #162