### PR TITLE
fix: incorpora melhorias transversais do dossier

### DIFF
--- a/api/Attributes/Cache.php
+++ b/api/Attributes/Cache.php
@@ -26,6 +26,8 @@ class Cache implements AttributesInterface, AttributeBefore, AttributeAfter
 
     private string $key;
     private int $time;
+    private bool $hit = false;
+
     public function __construct(...$parms)
     {
         $post = new Post();
@@ -49,13 +51,19 @@ class Cache implements AttributesInterface, AttributeBefore, AttributeAfter
     public function before(): null|Responseable
     {
         if (CoreCache::exists($this->key)) {
+            $this->hit = true;
             return CoreCache::get($this->key);
         }
+
         return null;
     }
 
     public function after(Responseable $response): void
     {
+        if ($this->hit) {
+            return;
+        }
+
         CoreCache::set($this->key, $response, $this->time);
     }
 

--- a/api/Core/Autoload.php
+++ b/api/Core/Autoload.php
@@ -30,10 +30,11 @@ foreach ($composerAutoloadCandidates as $composerAutoload) {
 spl_autoload_register(
     function (string $className): bool {
         $prefix = 'Bifrost\\';
-        if (strpos($className, $prefix) === 0) {
-            $className = substr($className, strlen($prefix));
+        if (!str_starts_with($className, $prefix)) {
+            return false;
         }
 
+        $className = substr($className, strlen($prefix));
         $relativeFile = str_replace("\\", DIRECTORY_SEPARATOR, $className) . ".php";
         $file = __DIR__ . DIRECTORY_SEPARATOR . ".." . DIRECTORY_SEPARATOR . $relativeFile;
         if (is_readable($file)) {
@@ -44,8 +45,9 @@ spl_autoload_register(
         $lowercaseFile = dirname($file) . DIRECTORY_SEPARATOR . lcfirst(basename($file));
         if (is_readable($lowercaseFile)) {
             require_once $lowercaseFile;
+            return true;
         }
 
-        return true;
+        return false;
     }
 );

--- a/api/Core/Get.php
+++ b/api/Core/Get.php
@@ -19,12 +19,15 @@ class Get
 
         $data = $_GET;
         $path = $data["_controller"] ?? "index";
+        $hasExplicitAction = !empty($data["_action"]);
         $action = empty($data["_action"]) ? "index" : $data["_action"];
         $route = Routes::fromRequest((string) $path);
         self::$routeMapped = $route !== null;
 
         if ($route) {
             [$controller, $action] = explode("/", $route->value);
+        } elseif (!$hasExplicitAction && str_contains((string) $path, "/")) {
+            [$controller, $action] = explode("/", (string) $path, 2);
         } else {
             $controller = (string) $path;
         }

--- a/api/Core/Session.php
+++ b/api/Core/Session.php
@@ -62,6 +62,13 @@ class Session
         }
     }
 
+    public static function close(): void
+    {
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            session_write_close();
+        }
+    }
+
     private function ensureSavePath(): void
     {
         if (session_module_name() !== 'files') {

--- a/api/Integration/Database/Driver/MysqlPdoDriver.php
+++ b/api/Integration/Database/Driver/MysqlPdoDriver.php
@@ -3,6 +3,7 @@
 namespace Bifrost\Integration\Database\Driver;
 
 use Bifrost\Integration\Database\PdoDatabase;
+use Bifrost\Interface\PdoDriverAdapter;
 use PDO;
 
 class MysqlPdoDriver implements PdoDriverAdapter

--- a/api/Integration/Database/Driver/PgsqlPdoDriver.php
+++ b/api/Integration/Database/Driver/PgsqlPdoDriver.php
@@ -3,6 +3,7 @@
 namespace Bifrost\Integration\Database\Driver;
 
 use Bifrost\Integration\Database\PdoDatabase;
+use Bifrost\Interface\PdoDriverAdapter;
 use PDO;
 
 class PgsqlPdoDriver implements PdoDriverAdapter

--- a/api/Integration/Database/Driver/SqlitePdoDriver.php
+++ b/api/Integration/Database/Driver/SqlitePdoDriver.php
@@ -3,6 +3,7 @@
 namespace Bifrost\Integration\Database\Driver;
 
 use Bifrost\Integration\Database\PdoDatabase;
+use Bifrost\Interface\PdoDriverAdapter;
 use PDO;
 
 class SqlitePdoDriver implements PdoDriverAdapter

--- a/api/Integration/Database/PdoDatabase.php
+++ b/api/Integration/Database/PdoDatabase.php
@@ -8,10 +8,10 @@ use Bifrost\Core\Functions;
 use Bifrost\Core\Settings;
 use Bifrost\Integration\Database\Driver\MysqlPdoDriver;
 use Bifrost\Integration\Database\Driver\PgsqlPdoDriver;
-use Bifrost\Integration\Database\Driver\PdoDriverAdapter;
 use Bifrost\Integration\Database\Driver\SqlitePdoDriver;
 use Bifrost\Interface\Database as DatabaseInterface;
 use Bifrost\Interface\Insertable;
+use Bifrost\Interface\PdoDriverAdapter;
 use PDO;
 use PDOException;
 
@@ -120,6 +120,10 @@ class PdoDatabase implements DatabaseInterface
             
             if (is_string($value)) {
                 $value = "'{$value}'";
+            } elseif (is_bool($value)) {
+                $value = $value ? 'TRUE' : 'FALSE';
+            } elseif ($value === null) {
+                $value = 'NULL';
             }
             $fields[] = "{$key} = {$value}";
         }

--- a/api/Interface/PdoDriverAdapter.php
+++ b/api/Interface/PdoDriverAdapter.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Bifrost\Integration\Database\Driver;
+namespace Bifrost\Interface;
 
 use Bifrost\Integration\Database\PdoDatabase;
 use PDO;
@@ -15,3 +15,5 @@ interface PdoDriverAdapter
 
     public function setSystemIdentifier(PDO $connection, array $data): bool;
 }
+
+class_alias(PdoDriverAdapter::class, 'Bifrost\\Integration\\Database\\Driver\\PdoDriverAdapter');

--- a/api/tests/Attributes/CacheAttributeHitTest.php
+++ b/api/tests/Attributes/CacheAttributeHitTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+use Bifrost\Attributes\Cache as CacheAttribute;
+use Bifrost\Class\HttpResponse;
+use Bifrost\Integration\Cache\RedisCache;
+use PHPUnit\Framework\TestCase;
+
+final class CacheAttributeHitTest extends TestCase
+{
+    private FakeRedisForCacheAttribute $redis;
+
+    protected function setUp(): void
+    {
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        bifrost_reset_get();
+        bifrost_set_post_data([]);
+        bifrost_reset_session();
+
+        $this->redis = new FakeRedisForCacheAttribute(HttpResponse::success('cached'));
+        $this->setRedisCacheState(redis: $this->redis, enabled: true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->setRedisCacheState(redis: null, enabled: true);
+    }
+
+    public function testAfterDoesNotRewriteCacheWhenBeforeReturnedHit(): void
+    {
+        $attribute = new CacheAttribute(60);
+
+        $cached = $attribute->before();
+        $attribute->after(HttpResponse::success('fresh'));
+
+        self::assertInstanceOf(HttpResponse::class, $cached);
+        self::assertSame(0, $this->redis->setCount);
+    }
+
+    private function setRedisCacheState(?FakeRedisForCacheAttribute $redis, bool $enabled): void
+    {
+        $redisProperty = new ReflectionProperty(RedisCache::class, 'redis');
+        $redisProperty->setAccessible(true);
+        $redisProperty->setValue(null, $redis);
+
+        $enabledProperty = new ReflectionProperty(RedisCache::class, 'enabled');
+        $enabledProperty->setAccessible(true);
+        $enabledProperty->setValue(null, $enabled);
+    }
+}
+
+final class FakeRedisForCacheAttribute
+{
+    public int $setCount = 0;
+    private mixed $value;
+
+    public function __construct(mixed $value)
+    {
+        $this->value = $value;
+    }
+
+    public function exists(string $key): int
+    {
+        return 1;
+    }
+
+    public function get(string $key): string
+    {
+        return serialize($this->value);
+    }
+
+    public function set(string $key, string $value, int $expire): bool
+    {
+        $this->setCount++;
+        return true;
+    }
+
+    public function del(string $key): int
+    {
+        return 1;
+    }
+}

--- a/api/tests/Core/AutoloadReturnTest.php
+++ b/api/tests/Core/AutoloadReturnTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class AutoloadReturnTest extends TestCase
+{
+    public function testBifrostAutoloaderReturnsFalseWhenClassIsOutsidePrefix(): void
+    {
+        self::assertFalse($this->bifrostAutoloader()('Vendor\\MissingClass'));
+    }
+
+    public function testBifrostAutoloaderReturnsFalseWhenFileDoesNotExist(): void
+    {
+        self::assertFalse($this->bifrostAutoloader()('Bifrost\\MissingClass'));
+    }
+
+    private function bifrostAutoloader(): Closure
+    {
+        foreach (spl_autoload_functions() as $autoloader) {
+            if (!$autoloader instanceof Closure) {
+                continue;
+            }
+
+            $reflection = new ReflectionFunction($autoloader);
+            if ($reflection->getFileName() === dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'Core' . DIRECTORY_SEPARATOR . 'Autoload.php') {
+                return $autoloader;
+            }
+        }
+
+        self::fail('Bifrost autoloader not found.');
+    }
+}

--- a/api/tests/Core/GetPathActionFallbackTest.php
+++ b/api/tests/Core/GetPathActionFallbackTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Bifrost\Core\Get;
+use PHPUnit\Framework\TestCase;
+
+final class GetPathActionFallbackTest extends TestCase
+{
+    public function testUnmappedControllerPathCanCarryAction(): void
+    {
+        $get = bifrost_reset_get(['_controller' => 'documents/presignUpload']);
+
+        self::assertSame('documents', $get->controller);
+        self::assertSame('presignUpload', $get->action);
+        self::assertFalse(Get::$routeMapped);
+    }
+
+    public function testExplicitActionKeepsControllerPathUnchanged(): void
+    {
+        $get = bifrost_reset_get([
+            '_controller' => 'documents/presignUpload',
+            '_action' => 'index',
+        ]);
+
+        self::assertSame('documents/presignUpload', $get->controller);
+        self::assertSame('index', $get->action);
+        self::assertFalse(Get::$routeMapped);
+    }
+}

--- a/api/tests/Core/SessionCloseTest.php
+++ b/api/tests/Core/SessionCloseTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use Bifrost\Core\Session;
+use PHPUnit\Framework\TestCase;
+
+final class SessionCloseTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        if (session_status() !== PHP_SESSION_ACTIVE && session_id() !== '') {
+            session_start();
+        }
+
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            session_unset();
+            session_destroy();
+        }
+
+        session_id('');
+    }
+
+    public function testCloseWritesAndClosesActiveSession(): void
+    {
+        $session = bifrost_reset_session(['tenant' => 'acme']);
+
+        Session::close();
+
+        self::assertSame(PHP_SESSION_NONE, session_status());
+
+        session_start();
+        self::assertSame('acme', $session->tenant);
+    }
+}

--- a/api/tests/Integration/PdoDatabaseUpdateTest.php
+++ b/api/tests/Integration/PdoDatabaseUpdateTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use Bifrost\Core\Database;
+use PHPUnit\Framework\TestCase;
+
+final class PdoDatabaseUpdateTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        bifrost_reset_database();
+    }
+
+    public function testUpdateWritesNullAndBooleanValues(): void
+    {
+        $database = new Database();
+
+        self::assertTrue($database->update(
+            table: 'users',
+            data: [
+                'email' => null,
+                'active' => false,
+            ],
+            where: ['name' => 'Alice']
+        ));
+
+        $rows = $database->select(
+            table: 'users',
+            fields: ['email', 'active'],
+            where: ['name' => 'Alice']
+        );
+
+        self::assertNull($rows[0]['email']);
+        self::assertSame(0, (int) $rows[0]['active']);
+    }
+}

--- a/api/tests/Interface/PdoDriverAdapterNamespaceTest.php
+++ b/api/tests/Interface/PdoDriverAdapterNamespaceTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use Bifrost\Integration\Database\Driver\MysqlPdoDriver;
+use Bifrost\Integration\Database\Driver\PgsqlPdoDriver;
+use Bifrost\Integration\Database\Driver\SqlitePdoDriver;
+use Bifrost\Interface\PdoDriverAdapter;
+use PHPUnit\Framework\TestCase;
+
+final class PdoDriverAdapterNamespaceTest extends TestCase
+{
+    public function testDriversImplementInterfaceNamespaceContract(): void
+    {
+        self::assertContains(PdoDriverAdapter::class, class_implements(MysqlPdoDriver::class));
+        self::assertContains(PdoDriverAdapter::class, class_implements(PgsqlPdoDriver::class));
+        self::assertContains(PdoDriverAdapter::class, class_implements(SqlitePdoDriver::class));
+    }
+
+    public function testLegacyDriverNamespaceAliasIsPreserved(): void
+    {
+        self::assertTrue(interface_exists(Bifrost\Integration\Database\Driver\PdoDriverAdapter::class));
+        self::assertTrue(
+            is_a(
+                PdoDriverAdapter::class,
+                Bifrost\Integration\Database\Driver\PdoDriverAdapter::class,
+                true
+            )
+        );
+    }
+}


### PR DESCRIPTION
## Objetivo

Incorporar no framework apenas as melhorias transversais identificadas no Dossier, sem trazer regra específica de produto.

## Principais mudanças

- Corrige o namespace do contrato `PdoDriverAdapter` e mantém alias legado de compatibilidade.
- Trata `NULL` e booleanos em `UPDATE` SQL.
- Adiciona `Session::close()` para liberar sessão ativa.
- Evita regravar cache quando o atributo já retornou hit.
- Permite fallback `controller/action` em rotas livres sem enum.
- Ajusta retorno do autoloader quando a classe não é carregada.
- Adiciona testes focados para as regressões cobertas.

## Testes executados

- `docker compose -f api\Docker\docker-compose.dev.yml run --rm --no-deps api1 composer test -- --filter PdoDriverAdapterNamespaceTest|PdoDatabaseUpdateTest|SessionCloseTest|GetPathActionFallbackTest|AutoloadReturnTest|CacheAttributeHitTest`
- `docker compose -f api\Docker\docker-compose.dev.yml run --rm --no-deps api1 composer lint`
- `docker compose -f api\Docker\docker-compose.dev.yml run --rm --no-deps api1 vendor/bin/php-cs-fixer fix --dry-run --diff --config=.php-cs-fixer.dist.php --allow-risky=no ...arquivos alterados...`
- `docker compose -f api\Docker\docker-compose.dev.yml run --rm --no-deps api1 composer analyse`
- `docker compose -f api\Docker\docker-compose.dev.yml run --rm --no-deps api1 composer test`

## Riscos ou pontos de atenção

- PR empilhado sobre `infra/prod-local-performance` para não misturar com o PR de performance.
- `composer check` completo ainda acusa formatação em arquivos preexistentes fora do escopo; os arquivos alterados passaram no format check focado.