### PR TITLE
feat: adiciona worker de filas e suporte SQLite

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/.github/workflows/modular-packages.yml
+++ b/.github/workflows/modular-packages.yml
@@ -50,7 +50,7 @@ jobs:
           php-version: '8.3'
           tools: composer:2
           coverage: none
-          extensions: json, redis, apcu, mongodb, pdo, pdo_mysql, pdo_pgsql
+          extensions: json, redis, apcu, mongodb, pdo, pdo_mysql, pdo_pgsql, pdo_sqlite
 
       - name: Install framework dependencies
         run: composer install --working-dir=packages/framework --no-interaction --no-progress --prefer-dist
@@ -73,7 +73,7 @@ jobs:
             composer validate --strict --no-check-publish
             composer test
           done
-          for package in database-mysql database-postgresql; do
+          for package in database-mysql database-postgresql database-sqlite; do
             cd "$GITHUB_WORKSPACE/packages/$package"
             composer config minimum-stability dev
             composer config repositories.framework path ../framework

--- a/.github/workflows/modular-packages.yml
+++ b/.github/workflows/modular-packages.yml
@@ -65,7 +65,7 @@ jobs:
           MYSQL_HOST: 127.0.0.1
           POSTGRES_HOST: 127.0.0.1
         run: |
-          for package in datatypes cache-redis cache-apcu queue-redis database-pdo log-mongodb storage-local storage-s3; do
+          for package in datatypes cache-redis cache-apcu queue-redis queue-worker database-pdo log-mongodb storage-local storage-s3; do
             cd "$GITHUB_WORKSPACE/packages/$package"
             composer config minimum-stability dev
             composer config repositories.framework path ../framework

--- a/docker/modular/check.sh
+++ b/docker/modular/check.sh
@@ -17,7 +17,7 @@ for package in datatypes cache-redis cache-apcu queue-redis queue-worker databas
     )
 done
 
-for package in database-mysql database-postgresql; do
+for package in database-mysql database-postgresql database-sqlite; do
     (
         cd "packages/$package"
         composer validate --strict --no-check-publish composer.json

--- a/docker/modular/check.sh
+++ b/docker/modular/check.sh
@@ -6,7 +6,7 @@ composer validate --strict --no-check-publish packages/framework/composer.json
 composer install --working-dir=packages/framework --no-interaction --no-progress --prefer-dist
 composer check --working-dir=packages/framework
 
-for package in datatypes cache-redis cache-apcu queue-redis database-pdo log-mongodb storage-local storage-s3; do
+for package in datatypes cache-redis cache-apcu queue-redis queue-worker database-pdo log-mongodb storage-local storage-s3; do
     (
         cd "packages/$package"
         composer validate --strict --no-check-publish composer.json

--- a/packages/database-pdo/README.md
+++ b/packages/database-pdo/README.md
@@ -1,6 +1,10 @@
 # bifrost/database-pdo
 
-Fabrica opcional de conexoes PDO para o Bifrost Framework.
+Fabrica opcional de conexoes PDO e helper simples de consultas para o Bifrost Framework.
 
 Registre `PdoExtension` com `dsn`, `username`, `password` e `options`, ou use
 `connections` para configurar multiplas conexoes nomeadas.
+
+Ao registrar a extensao, o container tambem recebe `PdoDatabase`, com metodos
+para `execute`, `fetch`, `fetchAll`, `value`, `select`, `insert`, `update`,
+`delete` e `exists`.

--- a/packages/database-pdo/src/PdoDatabase.php
+++ b/packages/database-pdo/src/PdoDatabase.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bifrost\Extension\DatabasePdo;
+
+use InvalidArgumentException;
+use PDO;
+use PDOStatement;
+
+final class PdoDatabase
+{
+    public function __construct(private readonly PDO $connection)
+    {
+    }
+
+    public function connection(): PDO
+    {
+        return $this->connection;
+    }
+
+    public function driver(): string
+    {
+        $driver = $this->connection->getAttribute(PDO::ATTR_DRIVER_NAME);
+
+        return is_string($driver) ? $driver : 'unknown';
+    }
+
+    public function supportsReturning(): bool
+    {
+        return $this->driver() === 'pgsql';
+    }
+
+    public function begin(): bool
+    {
+        return $this->connection->beginTransaction();
+    }
+
+    public function rollback(): bool
+    {
+        return $this->connection->rollBack();
+    }
+
+    public function commit(): bool
+    {
+        return $this->connection->commit();
+    }
+
+    public function execute(string $sql, array $params = []): PDOStatement
+    {
+        $statement = $this->connection->prepare($sql);
+        $statement->execute($params);
+
+        return $statement;
+    }
+
+    public function fetchAll(string $sql, array $params = []): array
+    {
+        return $this->execute($sql, $params)->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    public function fetch(string $sql, array $params = []): ?array
+    {
+        $row = $this->execute($sql, $params)->fetch(PDO::FETCH_ASSOC);
+
+        return $row === false ? null : $row;
+    }
+
+    public function value(string $sql, array $params = []): mixed
+    {
+        $value = $this->execute($sql, $params)->fetchColumn();
+
+        return $value === false ? null : $value;
+    }
+
+    public function select(
+        string $table,
+        array|string $columns = '*',
+        array|string|null $where = null,
+        ?string $orderBy = null,
+        int|string|null $limit = null
+    ): array {
+        $params = [];
+        $sql = 'SELECT ' . $this->columnsSql($columns) . " FROM $table";
+        $whereSql = $this->whereSql($where, $params);
+
+        if ($whereSql !== '') {
+            $sql .= " WHERE $whereSql";
+        }
+
+        if ($orderBy !== null && $orderBy !== '') {
+            $sql .= " ORDER BY $orderBy";
+        }
+
+        if ($limit !== null && $limit !== '') {
+            $sql .= " LIMIT $limit";
+        }
+
+        return $this->fetchAll($sql, $params);
+    }
+
+    public function insert(string $table, array $data, ?string $returning = null): int|string
+    {
+        if ($data === []) {
+            throw new InvalidArgumentException('Insert PDO deve receber ao menos um campo.');
+        }
+
+        $columns = array_keys($data);
+        $placeholders = array_map(static fn (string $column): string => ':' . $column, $columns);
+        $sql = "INSERT INTO $table (" . implode(', ', $columns) . ') VALUES (' . implode(', ', $placeholders) . ')';
+
+        if ($returning !== null && $returning !== '' && $this->supportsReturning()) {
+            $sql .= " RETURNING $returning";
+            $value = $this->value($sql, $data);
+
+            return is_int($value) || is_string($value) ? $value : (string) $value;
+        }
+
+        $this->execute($sql, $data);
+
+        return $this->connection->lastInsertId();
+    }
+
+    public function update(string $table, array $data, array|string $where): int
+    {
+        if ($data === []) {
+            throw new InvalidArgumentException('Update PDO deve receber ao menos um campo.');
+        }
+
+        $params = [];
+        $sets = [];
+
+        foreach ($data as $column => $value) {
+            if (!is_string($column) || $column === '') {
+                throw new InvalidArgumentException('Update PDO deve receber campos nomeados.');
+            }
+
+            $placeholder = 'set_' . $column;
+            $sets[] = "$column = :$placeholder";
+            $params[$placeholder] = $value;
+        }
+
+        $whereSql = $this->whereSql($where, $params);
+        $statement = $this->execute("UPDATE $table SET " . implode(', ', $sets) . " WHERE $whereSql", $params);
+
+        return $statement->rowCount();
+    }
+
+    public function delete(string $table, array|string $where): int
+    {
+        $params = [];
+        $whereSql = $this->whereSql($where, $params);
+        $statement = $this->execute("DELETE FROM $table WHERE $whereSql", $params);
+
+        return $statement->rowCount();
+    }
+
+    public function exists(string $table, array|string|null $where = null): bool
+    {
+        $params = [];
+        $whereSql = $this->whereSql($where, $params);
+        $sql = "SELECT 1 FROM $table" . ($whereSql === '' ? '' : " WHERE $whereSql") . ' LIMIT 1';
+
+        return $this->value($sql, $params) !== null;
+    }
+
+    private function columnsSql(array|string $columns): string
+    {
+        if (is_string($columns)) {
+            return $columns;
+        }
+
+        if ($columns === []) {
+            return '*';
+        }
+
+        return implode(', ', $columns);
+    }
+
+    private function whereSql(array|string|null $where, array &$params): string
+    {
+        if ($where === null || $where === []) {
+            return '';
+        }
+
+        if (is_string($where)) {
+            return $where;
+        }
+
+        $parts = [];
+        foreach ($where as $column => $value) {
+            if (is_int($column)) {
+                $parts[] = (string) $value;
+                continue;
+            }
+
+            if ($value === null) {
+                $parts[] = "$column IS NULL";
+                continue;
+            }
+
+            if (is_array($value)) {
+                $placeholders = [];
+                foreach (array_values($value) as $index => $item) {
+                    $placeholder = 'where_' . $column . '_' . $index;
+                    $placeholders[] = ":$placeholder";
+                    $params[$placeholder] = $item;
+                }
+
+                $parts[] = "$column IN (" . implode(', ', $placeholders) . ')';
+                continue;
+            }
+
+            $placeholder = 'where_' . $column;
+            $parts[] = "$column = :$placeholder";
+            $params[$placeholder] = $value;
+        }
+
+        return implode(' AND ', $parts);
+    }
+}

--- a/packages/database-pdo/src/PdoExtension.php
+++ b/packages/database-pdo/src/PdoExtension.php
@@ -7,6 +7,7 @@ namespace Bifrost\Extension\DatabasePdo;
 use Bifrost\Framework\Application;
 use Bifrost\Framework\Contracts\DatabaseConnectionFactory;
 use Bifrost\Framework\Contracts\Extension;
+use Bifrost\Framework\Container;
 
 final class PdoExtension implements Extension
 {
@@ -16,9 +17,18 @@ final class PdoExtension implements Extension
 
     public function register(Application $application): void
     {
+        $factory = new PdoConnectionFactory(config: $this->config);
+
         $application->container()->bind(
             DatabaseConnectionFactory::class,
-            new PdoConnectionFactory(config: $this->config)
+            $factory
+        );
+
+        $application->container()->bind(
+            PdoDatabase::class,
+            static fn (Container $container): PdoDatabase => new PdoDatabase(
+                connection: $container->get(DatabaseConnectionFactory::class)->connection()
+            )
         );
     }
 }

--- a/packages/database-pdo/tests/PdoConnectionFactoryTest.php
+++ b/packages/database-pdo/tests/PdoConnectionFactoryTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Bifrost\Extension\DatabasePdo\PdoExtension;
+use Bifrost\Extension\DatabasePdo\PdoDatabase;
 use Bifrost\Framework\Application;
 use Bifrost\Framework\Contracts\DatabaseConnectionFactory;
 use PHPUnit\Framework\TestCase;
@@ -16,5 +17,23 @@ final class PdoConnectionFactoryTest extends TestCase
 
         self::assertSame($factory->connection(), $factory->connection());
         self::assertSame(1, (int) $factory->connection()->query('SELECT 1')->fetchColumn());
+    }
+
+    public function testPdoDatabaseExecutesCrudQueries(): void
+    {
+        $application = Application::create()->extend(new PdoExtension(['dsn' => 'sqlite::memory:']));
+        $database = $application->container()->get(PdoDatabase::class);
+
+        $database->execute('CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, active INTEGER NOT NULL)');
+
+        $id = $database->insert('users', ['name' => 'Ana', 'active' => 1]);
+
+        self::assertSame('1', $id);
+        self::assertTrue($database->exists('users', ['name' => 'Ana']));
+        self::assertSame([['id' => 1, 'name' => 'Ana']], $database->select('users', ['id', 'name'], ['active' => 1]));
+        self::assertSame(1, $database->update('users', ['name' => 'Maria'], ['id' => 1]));
+        self::assertSame('Maria', $database->value('SELECT name FROM users WHERE id = :id', ['id' => 1]));
+        self::assertSame(1, $database->delete('users', ['id' => 1]));
+        self::assertFalse($database->exists('users', ['id' => 1]));
     }
 }

--- a/packages/database-sqlite/README.md
+++ b/packages/database-sqlite/README.md
@@ -1,0 +1,6 @@
+# bifrost/database-sqlite
+
+Extensao opcional SQLite baseada em `bifrost/database-pdo`.
+
+Registre `SqliteExtension` com `path` para arquivo local ou `memory` como
+`true` para banco em memoria. A chave `connections` habilita conexoes nomeadas.

--- a/packages/database-sqlite/composer.json
+++ b/packages/database-sqlite/composer.json
@@ -1,0 +1,28 @@
+{
+  "name": "bifrost/database-sqlite",
+  "description": "Extensao SQLite opcional para o Bifrost Framework",
+  "type": "library",
+  "license": "MIT",
+  "require": {
+    "php": ">=8.1",
+    "bifrost/database-pdo": "^1.0",
+    "bifrost/framework": "^1.0",
+    "ext-pdo_sqlite": "*"
+  },
+  "autoload": {
+    "psr-4": {
+      "Bifrost\\Extension\\DatabaseSqlite\\": "src/"
+    }
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^10.5 || ^11.0 || ^12.0"
+  },
+  "scripts": {
+    "test": "phpunit -c phpunit.xml"
+  },
+  "extra": {
+    "branch-alias": {
+      "dev-main": "1.0-dev"
+    }
+  }
+}

--- a/packages/database-sqlite/phpunit.xml
+++ b/packages/database-sqlite/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php" colors="true" failOnWarning="true">
+    <testsuites>
+        <testsuite name="Bifrost Database SQLite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/packages/database-sqlite/src/SqliteExtension.php
+++ b/packages/database-sqlite/src/SqliteExtension.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bifrost\Extension\DatabaseSqlite;
+
+use Bifrost\Extension\DatabasePdo\PdoConnectionFactory;
+use Bifrost\Extension\DatabasePdo\PdoDatabase;
+use Bifrost\Framework\Application;
+use Bifrost\Framework\Container;
+use Bifrost\Framework\Contracts\DatabaseConnectionFactory;
+use Bifrost\Framework\Contracts\Extension;
+use InvalidArgumentException;
+
+final class SqliteExtension implements Extension
+{
+    public function __construct(private readonly array $config)
+    {
+    }
+
+    public function register(Application $application): void
+    {
+        $factory = new PdoConnectionFactory(config: $this->pdoConfig());
+
+        $application->container()->bind(
+            DatabaseConnectionFactory::class,
+            $factory
+        );
+
+        $application->container()->bind(
+            PdoDatabase::class,
+            static fn (Container $container): PdoDatabase => new PdoDatabase(
+                connection: $container->get(DatabaseConnectionFactory::class)->connection()
+            )
+        );
+    }
+
+    private function pdoConfig(): array
+    {
+        if (!isset($this->config['connections'])) {
+            return $this->withDsn($this->config);
+        }
+
+        $connections = [];
+        foreach ($this->config['connections'] as $name => $config) {
+            if (!is_array($config)) {
+                throw new InvalidArgumentException("Configuracao SQLite '$name' deve ser um array.");
+            }
+
+            $connections[$name] = $this->withDsn($config);
+        }
+
+        return ['connections' => $connections];
+    }
+
+    private function withDsn(array $config): array
+    {
+        if (($config['memory'] ?? false) === true) {
+            $config['dsn'] = 'sqlite::memory:';
+
+            return $config;
+        }
+
+        $path = $config['path'] ?? null;
+        if (!is_string($path) || $path === '') {
+            throw new InvalidArgumentException('A configuracao SQLite deve informar path ou memory=true.');
+        }
+
+        $config['dsn'] = "sqlite:$path";
+
+        return $config;
+    }
+}

--- a/packages/database-sqlite/tests/SqliteExtensionTest.php
+++ b/packages/database-sqlite/tests/SqliteExtensionTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+use Bifrost\Extension\DatabaseSqlite\SqliteExtension;
+use Bifrost\Extension\DatabasePdo\PdoDatabase;
+use Bifrost\Framework\Application;
+use Bifrost\Framework\Contracts\DatabaseConnectionFactory;
+use PHPUnit\Framework\TestCase;
+
+final class SqliteExtensionTest extends TestCase
+{
+    public function testConnectsUsingMemoryDatabase(): void
+    {
+        $application = Application::create()->extend(new SqliteExtension(['memory' => true]));
+        $factory = $application->container()->get(DatabaseConnectionFactory::class);
+
+        self::assertSame('sqlite', $factory->connection()->getAttribute(PDO::ATTR_DRIVER_NAME));
+        self::assertSame(1, (int) $factory->connection()->query('SELECT 1')->fetchColumn());
+    }
+
+    public function testConnectsUsingNamedConnections(): void
+    {
+        $application = Application::create()->extend(new SqliteExtension([
+            'connections' => [
+                'default' => ['memory' => true],
+                'analytics' => ['memory' => true],
+            ],
+        ]));
+        $factory = $application->container()->get(DatabaseConnectionFactory::class);
+
+        self::assertNotSame($factory->connection(), $factory->connection('analytics'));
+        self::assertSame('sqlite', $factory->connection('analytics')->getAttribute(PDO::ATTR_DRIVER_NAME));
+    }
+
+    public function testRegistersPdoDatabaseHelper(): void
+    {
+        $application = Application::create()->extend(new SqliteExtension(['memory' => true]));
+        $database = $application->container()->get(PdoDatabase::class);
+
+        $database->execute('CREATE TABLE events (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL)');
+        $database->insert('events', ['name' => 'created']);
+
+        self::assertSame('created', $database->value('SELECT name FROM events WHERE id = :id', ['id' => 1]));
+    }
+}

--- a/packages/database-sqlite/tests/bootstrap.php
+++ b/packages/database-sqlite/tests/bootstrap.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+require dirname(__DIR__) . '/vendor/autoload.php';

--- a/packages/queue-worker/README.md
+++ b/packages/queue-worker/README.md
@@ -1,0 +1,16 @@
+# bifrost/queue-worker
+
+Worker opcional para consumir tarefas publicadas em qualquer implementacao do
+contrato `Bifrost\Framework\Contracts\Queue`.
+
+```php
+$payload = new TaskPayload('emails.send', ['email' => 'user@example.com']);
+$queue->push('default', $payload->toArray());
+
+$registry = (new TaskRegistry())->add('emails.send', new SendEmailTaskHandler());
+$worker = new QueueWorker($queue, $registry);
+$worker->workOnce('default');
+```
+
+Use `TaskPayload::fromArray()` para reconstruir payloads serializados pela fila.
+O worker reencaminha tarefas com falha enquanto `maxAttempts` nao for atingido.

--- a/packages/queue-worker/composer.json
+++ b/packages/queue-worker/composer.json
@@ -1,0 +1,26 @@
+{
+  "name": "bifrost/queue-worker",
+  "description": "Worker opcional para consumir filas do Bifrost Framework",
+  "type": "library",
+  "license": "MIT",
+  "require": {
+    "php": ">=8.1",
+    "bifrost/framework": "^1.0"
+  },
+  "autoload": {
+    "psr-4": {
+      "Bifrost\\Extension\\QueueWorker\\": "src/"
+    }
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^10.5 || ^11.0 || ^12.0"
+  },
+  "scripts": {
+    "test": "phpunit -c phpunit.xml"
+  },
+  "extra": {
+    "branch-alias": {
+      "dev-main": "1.0-dev"
+    }
+  }
+}

--- a/packages/queue-worker/phpunit.xml
+++ b/packages/queue-worker/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php" colors="true" failOnWarning="true">
+    <testsuites>
+        <testsuite name="Bifrost Queue Worker">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/packages/queue-worker/src/QueueWorker.php
+++ b/packages/queue-worker/src/QueueWorker.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bifrost\Extension\QueueWorker;
+
+use Bifrost\Framework\Contracts\Queue;
+use Throwable;
+
+final class QueueWorker
+{
+    public function __construct(
+        private readonly Queue $queue,
+        private readonly TaskRegistry $tasks
+    ) {
+    }
+
+    public function workOnce(string $queue): WorkerResult
+    {
+        $payload = $this->queue->pop($queue);
+
+        if ($payload === null) {
+            return WorkerResult::idle();
+        }
+
+        $taskPayload = TaskPayload::fromArray($payload);
+
+        try {
+            $this->tasks->handle($taskPayload);
+
+            return WorkerResult::processed($taskPayload);
+        } catch (Throwable $error) {
+            $failedPayload = $taskPayload->withRecordedFailure();
+
+            if ($failedPayload->canRetry()) {
+                $this->queue->push($queue, $failedPayload->toArray());
+
+                return WorkerResult::retried($failedPayload, $error);
+            }
+
+            return WorkerResult::failed($failedPayload, $error);
+        }
+    }
+}

--- a/packages/queue-worker/src/QueueWorkerCommand.php
+++ b/packages/queue-worker/src/QueueWorkerCommand.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bifrost\Extension\QueueWorker;
+
+final class QueueWorkerCommand
+{
+    public function __construct(
+        private readonly QueueWorker $worker,
+        private readonly int $defaultSleepSeconds = 1
+    ) {
+    }
+
+    public function run(array $argv): int
+    {
+        $options = $this->options($argv);
+        $queue = $options['queue'];
+        $sleepSeconds = $options['sleep'];
+        $maxJobs = $options['max_jobs'];
+        $processedJobs = 0;
+
+        while (true) {
+            $result = $this->worker->workOnce($queue);
+
+            if ($result->isFailed()) {
+                fwrite(STDERR, sprintf("Tarefa falhou definitivamente na fila %s.\n", $queue));
+
+                return 1;
+            }
+
+            if ($result->isProcessed() || $result->isRetried()) {
+                $processedJobs++;
+            }
+
+            if ($maxJobs > 0 && $processedJobs >= $maxJobs) {
+                return 0;
+            }
+
+            if ($result->isIdle()) {
+                sleep($sleepSeconds);
+            }
+        }
+    }
+
+    /**
+     * @return array{queue: string, sleep: int, max_jobs: int}
+     */
+    private function options(array $argv): array
+    {
+        $options = [
+            'queue' => getenv('QUEUE_NAME') ?: 'default',
+            'sleep' => $this->defaultSleepSeconds,
+            'max_jobs' => 0,
+        ];
+
+        foreach (array_slice($argv, 1) as $argument) {
+            if (str_starts_with($argument, '--queue=')) {
+                $options['queue'] = substr($argument, 8);
+                continue;
+            }
+
+            if (str_starts_with($argument, '--sleep=')) {
+                $options['sleep'] = max(0, (int) substr($argument, 8));
+                continue;
+            }
+
+            if (str_starts_with($argument, '--max-jobs=')) {
+                $options['max_jobs'] = max(0, (int) substr($argument, 11));
+            }
+        }
+
+        return $options;
+    }
+}

--- a/packages/queue-worker/src/TaskHandler.php
+++ b/packages/queue-worker/src/TaskHandler.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bifrost\Extension\QueueWorker;
+
+interface TaskHandler
+{
+    public function handle(TaskPayload $payload): void;
+}

--- a/packages/queue-worker/src/TaskPayload.php
+++ b/packages/queue-worker/src/TaskPayload.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bifrost\Extension\QueueWorker;
+
+use InvalidArgumentException;
+use JsonSerializable;
+
+final class TaskPayload implements JsonSerializable
+{
+    public function __construct(
+        private readonly string $task,
+        private readonly array $data = [],
+        private readonly int $attempts = 0,
+        private readonly int $maxAttempts = 3
+    ) {
+        if ($this->task === '') {
+            throw new InvalidArgumentException('O nome da tarefa nao pode ser vazio.');
+        }
+
+        if ($this->attempts < 0) {
+            throw new InvalidArgumentException('A quantidade de tentativas nao pode ser negativa.');
+        }
+
+        if ($this->maxAttempts < 1) {
+            throw new InvalidArgumentException('A quantidade maxima de tentativas deve ser maior que zero.');
+        }
+
+        self::assertSerializableArray($this->data);
+    }
+
+    public static function fromArray(array $payload): self
+    {
+        $task = $payload['task'] ?? null;
+        if (!is_string($task)) {
+            throw new InvalidArgumentException('Payload de tarefa deve conter task como string.');
+        }
+
+        $data = $payload['data'] ?? [];
+        if (!is_array($data)) {
+            throw new InvalidArgumentException('Payload de tarefa deve conter data como array.');
+        }
+
+        return new self(
+            task: $task,
+            data: $data,
+            attempts: self::integerValue($payload['attempts'] ?? 0, 'attempts'),
+            maxAttempts: self::integerValue($payload['max_attempts'] ?? 3, 'max_attempts')
+        );
+    }
+
+    public function task(): string
+    {
+        return $this->task;
+    }
+
+    public function data(): array
+    {
+        return $this->data;
+    }
+
+    public function attempts(): int
+    {
+        return $this->attempts;
+    }
+
+    public function maxAttempts(): int
+    {
+        return $this->maxAttempts;
+    }
+
+    public function withRecordedFailure(): self
+    {
+        return new self(
+            task: $this->task,
+            data: $this->data,
+            attempts: $this->attempts + 1,
+            maxAttempts: $this->maxAttempts
+        );
+    }
+
+    public function canRetry(): bool
+    {
+        return $this->attempts < $this->maxAttempts;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'task' => $this->task,
+            'data' => $this->data,
+            'attempts' => $this->attempts,
+            'max_attempts' => $this->maxAttempts,
+        ];
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+
+    private static function integerValue(mixed $value, string $field): int
+    {
+        if (!is_int($value)) {
+            throw new InvalidArgumentException(sprintf('Payload de tarefa deve conter %s como inteiro.', $field));
+        }
+
+        return $value;
+    }
+
+    private static function assertSerializableArray(array $value): void
+    {
+        foreach ($value as $item) {
+            if (is_array($item)) {
+                self::assertSerializableArray($item);
+                continue;
+            }
+
+            if ($item === null || is_bool($item) || is_int($item) || is_float($item) || is_string($item)) {
+                continue;
+            }
+
+            throw new InvalidArgumentException('Payload de tarefa aceita apenas valores escalares, nulos e arrays.');
+        }
+    }
+}

--- a/packages/queue-worker/src/TaskRegistry.php
+++ b/packages/queue-worker/src/TaskRegistry.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bifrost\Extension\QueueWorker;
+
+use RuntimeException;
+
+final class TaskRegistry
+{
+    /** @var array<string, TaskHandler|callable> */
+    private array $handlers = [];
+
+    public function add(string $task, TaskHandler|callable $handler): self
+    {
+        if ($task === '') {
+            throw new RuntimeException('O nome da tarefa nao pode ser vazio.');
+        }
+
+        $this->handlers[$task] = $handler;
+
+        return $this;
+    }
+
+    public function handle(TaskPayload $payload): void
+    {
+        $handler = $this->handlers[$payload->task()] ?? null;
+
+        if ($handler === null) {
+            throw new RuntimeException(sprintf('Nenhum handler registrado para a tarefa %s.', $payload->task()));
+        }
+
+        if ($handler instanceof TaskHandler) {
+            $handler->handle($payload);
+            return;
+        }
+
+        $handler($payload);
+    }
+}

--- a/packages/queue-worker/src/WorkerResult.php
+++ b/packages/queue-worker/src/WorkerResult.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bifrost\Extension\QueueWorker;
+
+use Throwable;
+
+final class WorkerResult
+{
+    private const IDLE = 'idle';
+    private const PROCESSED = 'processed';
+    private const RETRIED = 'retried';
+    private const FAILED = 'failed';
+
+    private function __construct(
+        private readonly string $status,
+        private readonly ?TaskPayload $payload = null,
+        private readonly ?Throwable $error = null
+    ) {
+    }
+
+    public static function idle(): self
+    {
+        return new self(self::IDLE);
+    }
+
+    public static function processed(TaskPayload $payload): self
+    {
+        return new self(self::PROCESSED, $payload);
+    }
+
+    public static function retried(TaskPayload $payload, Throwable $error): self
+    {
+        return new self(self::RETRIED, $payload, $error);
+    }
+
+    public static function failed(TaskPayload $payload, Throwable $error): self
+    {
+        return new self(self::FAILED, $payload, $error);
+    }
+
+    public function isIdle(): bool
+    {
+        return $this->status === self::IDLE;
+    }
+
+    public function isProcessed(): bool
+    {
+        return $this->status === self::PROCESSED;
+    }
+
+    public function isRetried(): bool
+    {
+        return $this->status === self::RETRIED;
+    }
+
+    public function isFailed(): bool
+    {
+        return $this->status === self::FAILED;
+    }
+
+    public function payload(): ?TaskPayload
+    {
+        return $this->payload;
+    }
+
+    public function error(): ?Throwable
+    {
+        return $this->error;
+    }
+}

--- a/packages/queue-worker/tests/QueueWorkerTest.php
+++ b/packages/queue-worker/tests/QueueWorkerTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+use Bifrost\Extension\QueueWorker\QueueWorker;
+use Bifrost\Extension\QueueWorker\TaskHandler;
+use Bifrost\Extension\QueueWorker\TaskPayload;
+use Bifrost\Extension\QueueWorker\TaskRegistry;
+use Bifrost\Framework\Contracts\Queue;
+use PHPUnit\Framework\TestCase;
+
+final class QueueWorkerTest extends TestCase
+{
+    public function testProcessesSerializedTaskPayload(): void
+    {
+        $queue = new FakeQueue();
+        $handledPayloads = [];
+        $registry = (new TaskRegistry())->add('emails.send', static function (TaskPayload $payload) use (&$handledPayloads): void {
+            $handledPayloads[] = $payload->data();
+        });
+        $worker = new QueueWorker($queue, $registry);
+
+        $queue->push('default', (new TaskPayload('emails.send', ['email' => 'user@example.com']))->toArray());
+        $result = $worker->workOnce('default');
+
+        self::assertTrue($result->isProcessed());
+        self::assertSame([['email' => 'user@example.com']], $handledPayloads);
+        self::assertNull($queue->pop('default'));
+    }
+
+    public function testRetriesFailedTaskUntilMaxAttempts(): void
+    {
+        $queue = new FakeQueue();
+        $registry = (new TaskRegistry())->add('always.fail', new FailingTaskHandler());
+        $worker = new QueueWorker($queue, $registry);
+
+        $queue->push('default', (new TaskPayload('always.fail', maxAttempts: 2))->toArray());
+
+        $firstResult = $worker->workOnce('default');
+        self::assertTrue($firstResult->isRetried());
+        self::assertSame(1, $firstResult->payload()?->attempts());
+
+        $secondResult = $worker->workOnce('default');
+        self::assertTrue($secondResult->isFailed());
+        self::assertSame(2, $secondResult->payload()?->attempts());
+        self::assertNull($queue->pop('default'));
+    }
+
+    public function testReturnsIdleWhenQueueIsEmpty(): void
+    {
+        $worker = new QueueWorker(new FakeQueue(), new TaskRegistry());
+
+        self::assertTrue($worker->workOnce('default')->isIdle());
+    }
+}
+
+final class FakeQueue implements Queue
+{
+    /** @var array<string, list<array>> */
+    private array $items = [];
+
+    public function push(string $queue, array $payload): void
+    {
+        $this->items[$queue][] = $payload;
+    }
+
+    public function pop(string $queue): ?array
+    {
+        if (($this->items[$queue] ?? []) === []) {
+            return null;
+        }
+
+        return array_shift($this->items[$queue]);
+    }
+}
+
+final class FailingTaskHandler implements TaskHandler
+{
+    public function handle(TaskPayload $payload): void
+    {
+        throw new RuntimeException('Falha intencional para teste.');
+    }
+}

--- a/packages/queue-worker/tests/bootstrap.php
+++ b/packages/queue-worker/tests/bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+
+require __DIR__ . '/../vendor/autoload.php';

--- a/skeleton/README.md
+++ b/skeleton/README.md
@@ -24,6 +24,7 @@ O bootstrap registra automaticamente os pacotes instalados:
 
 ```bash
 composer require bifrost/cache-redis bifrost/queue-redis
+composer require bifrost/queue-worker
 composer require bifrost/cache-apcu
 composer require bifrost/database-mysql
 # ou
@@ -37,6 +38,8 @@ composer require bifrost/cache-apcu
 docker compose -f docker-compose.yml -f compose/apcu.yml up --build
 composer require bifrost/cache-redis bifrost/queue-redis
 docker compose -f docker-compose.yml -f compose/redis.yml up --build
+composer require bifrost/queue-worker
+php worker.php --queue=default
 composer require bifrost/database-mysql
 docker compose -f docker-compose.yml -f compose/mysql.yml up --build
 composer require bifrost/database-postgresql
@@ -69,4 +72,6 @@ routes/api.php
 - `public/index.php` recebe e emite HTTP.
 - `bootstrap/app.php` cria a aplicacao e registra rotas/extensoes.
 - `config/extensions.php` ativa somente extensoes instaladas.
+- `worker.php` consome tarefas da fila configurada em Redis.
+- `app/Worker/tasks.php` registra handlers de tarefas do worker.
 - `app/` contem o codigo da aplicacao, usando o namespace `App\`.

--- a/skeleton/app/Worker/ExampleTaskHandler.php
+++ b/skeleton/app/Worker/ExampleTaskHandler.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Worker;
+
+use Bifrost\Extension\QueueWorker\TaskHandler;
+use Bifrost\Extension\QueueWorker\TaskPayload;
+
+final class ExampleTaskHandler implements TaskHandler
+{
+    public function handle(TaskPayload $payload): void
+    {
+        fwrite(STDOUT, sprintf("Tarefa %s processada.\n", $payload->task()));
+    }
+}

--- a/skeleton/app/Worker/tasks.php
+++ b/skeleton/app/Worker/tasks.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Worker\ExampleTaskHandler;
+use Bifrost\Extension\QueueWorker\TaskRegistry;
+
+return (new TaskRegistry())
+    ->add('example.ping', new ExampleTaskHandler());

--- a/skeleton/worker.php
+++ b/skeleton/worker.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Bifrost\Extension\QueueWorker\QueueWorker;
+use Bifrost\Extension\QueueWorker\QueueWorkerCommand;
+use Bifrost\Extension\QueueWorker\TaskRegistry;
+use Bifrost\Framework\Application;
+use Bifrost\Framework\Contracts\Queue;
+
+require __DIR__ . '/vendor/autoload.php';
+
+if (!class_exists(QueueWorker::class)) {
+    throw new RuntimeException('Instale bifrost/queue-worker para executar o worker de filas.');
+}
+
+/** @var Application $app */
+$app = require __DIR__ . '/bootstrap/app.php';
+
+/** @var TaskRegistry $tasks */
+$tasks = require __DIR__ . '/app/Worker/tasks.php';
+
+$command = new QueueWorkerCommand(new QueueWorker(
+    queue: $app->container()->get(Queue::class),
+    tasks: $tasks
+));
+
+exit($command->run($argv));


### PR DESCRIPTION
## Objetivo
Adicionar execução assíncrona e ampliar os bancos opcionais.

## Principais mudanças
- adiciona `bifrost/queue-worker` e entrypoint de worker no skeleton;
- adiciona consultas PDO reutilizáveis;
- adiciona `bifrost/database-sqlite`;
- preserva LF em scripts shell.

## Testes executados
- testes focados foram executados durante a implementação original;
- suíte modular completa pendente por timeout recente.

## Ordem de merge
PR 3. Depende do PR anterior.