### PR TITLE
feat: adiciona hooks HTTP, transações e logs opcionais

### DIFF
--- a/packages/database-pdo/src/PdoDatabase.php
+++ b/packages/database-pdo/src/PdoDatabase.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace Bifrost\Extension\DatabasePdo;
 
+use Bifrost\Framework\Contracts\TransactionManager;
 use InvalidArgumentException;
 use PDO;
 use PDOStatement;
 
-final class PdoDatabase
+final class PdoDatabase implements TransactionManager
 {
     public function __construct(private readonly PDO $connection)
     {

--- a/packages/database-pdo/src/PdoExtension.php
+++ b/packages/database-pdo/src/PdoExtension.php
@@ -5,9 +5,10 @@ declare(strict_types=1);
 namespace Bifrost\Extension\DatabasePdo;
 
 use Bifrost\Framework\Application;
+use Bifrost\Framework\Container;
 use Bifrost\Framework\Contracts\DatabaseConnectionFactory;
 use Bifrost\Framework\Contracts\Extension;
-use Bifrost\Framework\Container;
+use Bifrost\Framework\Contracts\TransactionManager;
 
 final class PdoExtension implements Extension
 {
@@ -29,6 +30,11 @@ final class PdoExtension implements Extension
             static fn (Container $container): PdoDatabase => new PdoDatabase(
                 connection: $container->get(DatabaseConnectionFactory::class)->connection()
             )
+        );
+
+        $application->container()->bind(
+            TransactionManager::class,
+            static fn (Container $container): TransactionManager => $container->get(PdoDatabase::class)
         );
     }
 }

--- a/packages/database-pdo/tests/PdoTransactionManagerTest.php
+++ b/packages/database-pdo/tests/PdoTransactionManagerTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+use Bifrost\Extension\DatabasePdo\PdoExtension;
+use Bifrost\Framework\Application;
+use Bifrost\Framework\Contracts\TransactionManager;
+use PHPUnit\Framework\TestCase;
+
+final class PdoTransactionManagerTest extends TestCase
+{
+    public function testRegistersPdoDatabaseAsTransactionManager(): void
+    {
+        $application = Application::create()->extend(new PdoExtension(['dsn' => 'sqlite::memory:']));
+        $transactionManager = $application->container()->get(TransactionManager::class);
+
+        self::assertInstanceOf(TransactionManager::class, $transactionManager);
+        self::assertTrue($transactionManager->begin());
+        self::assertTrue($transactionManager->rollback());
+    }
+}

--- a/packages/framework/src/Application.php
+++ b/packages/framework/src/Application.php
@@ -12,6 +12,11 @@ use Bifrost\Framework\Http\ResponseEmitter;
 use Bifrost\Framework\Routing\ControllerResolver;
 use Bifrost\Framework\Routing\Router;
 
+/**
+ * Ponto principal de configuracao e execucao de uma aplicacao Bifrost.
+ *
+ * Registra rotas, middlewares, extensoes e despacha requests para o kernel HTTP.
+ */
 final class Application
 {
     private readonly Router $router;
@@ -31,16 +36,27 @@ final class Application
         $this->emitter = new ResponseEmitter();
     }
 
+    /**
+     * Cria uma aplicacao Bifrost.
+     *
+     * @param bool $debug Quando true, respostas 500 podem expor a mensagem da excecao.
+     */
     public static function create(bool $debug = false): self
     {
         return new self(debug: $debug);
     }
 
+    /**
+     * Retorna o container de dependencias da aplicacao.
+     */
     public function container(): Container
     {
         return $this->container;
     }
 
+    /**
+     * Registra uma extensao do framework.
+     */
     public function extend(Extension $extension): self
     {
         $extension->register($this);
@@ -48,6 +64,11 @@ final class Application
         return $this;
     }
 
+    /**
+     * Adiciona um middleware HTTP.
+     *
+     * O middleware recebe Request e next callable, e deve retornar Response.
+     */
     public function middleware(callable $middleware): self
     {
         $this->kernel->middleware($middleware);
@@ -55,6 +76,11 @@ final class Application
         return $this;
     }
 
+    /**
+     * Registra uma rota HTTP.
+     *
+     * @param mixed $handler Callable ou par [Controller::class, 'metodo'].
+     */
     public function route(string $method, string $path, mixed $handler): self
     {
         $this->router->add(method: $method, path: $path, handler: $handler);
@@ -62,36 +88,67 @@ final class Application
         return $this;
     }
 
+    /**
+     * Registra uma rota GET.
+     *
+     * @param mixed $handler Callable ou par [Controller::class, 'metodo'].
+     */
     public function get(string $path, mixed $handler): self
     {
         return $this->route(method: 'GET', path: $path, handler: $handler);
     }
 
+    /**
+     * Registra uma rota POST.
+     *
+     * @param mixed $handler Callable ou par [Controller::class, 'metodo'].
+     */
     public function post(string $path, mixed $handler): self
     {
         return $this->route(method: 'POST', path: $path, handler: $handler);
     }
 
+    /**
+     * Registra uma rota PUT.
+     *
+     * @param mixed $handler Callable ou par [Controller::class, 'metodo'].
+     */
     public function put(string $path, mixed $handler): self
     {
         return $this->route(method: 'PUT', path: $path, handler: $handler);
     }
 
+    /**
+     * Registra uma rota PATCH.
+     *
+     * @param mixed $handler Callable ou par [Controller::class, 'metodo'].
+     */
     public function patch(string $path, mixed $handler): self
     {
         return $this->route(method: 'PATCH', path: $path, handler: $handler);
     }
 
+    /**
+     * Registra uma rota DELETE.
+     *
+     * @param mixed $handler Callable ou par [Controller::class, 'metodo'].
+     */
     public function delete(string $path, mixed $handler): self
     {
         return $this->route(method: 'DELETE', path: $path, handler: $handler);
     }
 
+    /**
+     * Processa uma request e retorna uma resposta.
+     */
     public function handle(Request $request): Response
     {
         return $this->kernel->handle($request);
     }
 
+    /**
+     * Envia a resposta HTTP para o cliente.
+     */
     public function emit(Response $response): void
     {
         $this->emitter->emit($response);

--- a/packages/framework/src/Attributes/Cache.php
+++ b/packages/framework/src/Attributes/Cache.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bifrost\Framework\Attributes;
+
+use Attribute;
+use Bifrost\Framework\Container;
+use Bifrost\Framework\Contracts\AfterResponseAttribute;
+use Bifrost\Framework\Contracts\BeforeRequestAttribute;
+use Bifrost\Framework\Contracts\CacheStore;
+use Bifrost\Framework\Http\Request;
+use Bifrost\Framework\Http\Response;
+use RuntimeException;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+/**
+ * Armazena a resposta de uma action em cache por tempo definido.
+ *
+ * Usa o CacheStore registrado no container. A chave considera metodo, path,
+ * query string, corpo da request e headers opcionais informados em varyByHeaders.
+ *
+ * Exemplo: #[Cache(seconds: 60, varyByHeaders: ['Authorization'])]
+ */
+final class Cache implements BeforeRequestAttribute, AfterResponseAttribute
+{
+    /**
+     * @param int $seconds Tempo de vida do cache em segundos.
+     * @param list<string> $varyByHeaders Headers que devem compor a chave de cache.
+     * @param array<string, mixed> $extra Valores adicionais para diferenciar a chave.
+     */
+    public function __construct(
+        private readonly int $seconds,
+        private readonly array $varyByHeaders = [],
+        private readonly array $extra = []
+    ) {
+    }
+
+    /**
+     * Retorna resposta em cache quando a chave existir.
+     */
+    public function before(Request $request, Container $container): ?Response
+    {
+        $cached = $this->cacheStore($container)->get($this->key($request));
+
+        return $cached instanceof Response ? $cached : null;
+    }
+
+    /**
+     * Salva respostas de sucesso no cache.
+     */
+    public function after(Request $request, Response $response, Container $container): ?Response
+    {
+        if ($response->status() >= 200 && $response->status() < 300) {
+            $this->cacheStore($container)->set($this->key($request), $response, $this->seconds);
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array{cache: array{seconds: int, varyByHeaders: list<string>}}
+     */
+    public function options(): array
+    {
+        return [
+            'cache' => [
+                'seconds' => $this->seconds,
+                'varyByHeaders' => $this->varyByHeaders,
+            ],
+        ];
+    }
+
+    private function cacheStore(Container $container): CacheStore
+    {
+        if (!$container->has(CacheStore::class)) {
+            throw new RuntimeException('CacheStore nao foi registrado no container.');
+        }
+
+        $cacheStore = $container->get(CacheStore::class);
+        if (!$cacheStore instanceof CacheStore) {
+            throw new RuntimeException('CacheStore registrado deve implementar Bifrost\\Framework\\Contracts\\CacheStore.');
+        }
+
+        return $cacheStore;
+    }
+
+    private function key(Request $request): string
+    {
+        $headers = [];
+        foreach ($this->varyByHeaders as $header) {
+            $headers[$header] = $request->header($header);
+        }
+
+        return hash('sha256', serialize([
+            'method' => $request->method(),
+            'path' => $request->path(),
+            'query' => $request->query(),
+            'body' => $request->input(),
+            'headers' => $headers,
+            'extra' => $this->extra,
+        ]));
+    }
+}

--- a/packages/framework/src/Attributes/Details.php
+++ b/packages/framework/src/Attributes/Details.php
@@ -8,12 +8,26 @@ use Attribute;
 use Bifrost\Framework\Contracts\HttpAttribute;
 
 #[Attribute(Attribute::TARGET_METHOD)]
+/**
+ * Adiciona metadados livres a uma action HTTP.
+ *
+ * Use para expor detalhes de documentacao, tags, resumo ou qualquer informacao
+ * consumida por ferramentas que leem attributes via OPTIONS.
+ *
+ * Exemplo: #[Details(['summary' => 'Lista usuarios', 'tags' => ['usuarios']])]
+ */
 final class Details implements HttpAttribute
 {
+    /**
+     * @param array<string, mixed> $details Metadados livres do endpoint.
+     */
     public function __construct(private readonly array $details)
     {
     }
 
+    /**
+     * @return array<string, mixed> Metadados informados no attribute.
+     */
     public function options(): array
     {
         return $this->details;

--- a/packages/framework/src/Attributes/Method.php
+++ b/packages/framework/src/Attributes/Method.php
@@ -10,16 +10,32 @@ use Bifrost\Framework\Http\Request;
 use Bifrost\Framework\Http\Response;
 
 #[Attribute(Attribute::TARGET_METHOD)]
+/**
+ * Restringe os metodos HTTP aceitos por uma action de controller.
+ *
+ * Use em endpoints que devem responder apenas a metodos especificos.
+ * Quando o metodo recebido nao estiver na lista, retorna 405 com header Allow.
+ *
+ * Exemplo: #[Method('GET', 'POST')]
+ */
 final class Method implements RequestValidatorAttribute
 {
     /** @var list<string> */
     private array $methods;
 
+    /**
+     * @param string ...$methods Metodos HTTP aceitos, como GET, POST, PUT, PATCH ou DELETE.
+     */
     public function __construct(string ...$methods)
     {
         $this->methods = array_map('strtoupper', $methods);
     }
 
+    /**
+     * Valida o metodo da request atual.
+     *
+     * @return Response|null Retorna null quando a request e valida, ou uma resposta 405 quando falha.
+     */
     public function validate(Request $request): ?Response
     {
         if (in_array($request->method(), $this->methods, true)) {
@@ -33,6 +49,9 @@ final class Method implements RequestValidatorAttribute
         );
     }
 
+    /**
+     * @return array{methods: list<string>} Metadados expostos para OPTIONS/documentacao do endpoint.
+     */
     public function options(): array
     {
         return ['methods' => $this->methods];

--- a/packages/framework/src/Attributes/OptionalFields.php
+++ b/packages/framework/src/Attributes/OptionalFields.php
@@ -11,12 +11,27 @@ use Bifrost\Framework\Http\Response;
 use Bifrost\Framework\Validation\ValidationRule;
 
 #[Attribute(Attribute::TARGET_METHOD)]
+/**
+ * Declara campos opcionais aceitos no corpo da request.
+ *
+ * Campos ausentes sao ignorados. Campos presentes sao validados pela regra informada.
+ *
+ * Exemplo: #[OptionalFields(['nickname' => 'string', 'age' => 'int'])]
+ */
 final class OptionalFields implements RequestValidatorAttribute
 {
+    /**
+     * @param array<string, mixed> $fields Mapa de campo opcional para regra de validacao.
+     */
     public function __construct(private readonly array $fields)
     {
     }
 
+    /**
+     * Valida apenas os campos opcionais presentes na request.
+     *
+     * @return Response|null Retorna null quando os campos presentes sao validos, ou resposta 400.
+     */
     public function validate(Request $request): ?Response
     {
         $errors = [];
@@ -43,6 +58,9 @@ final class OptionalFields implements RequestValidatorAttribute
         return Response::json(payload: ['message' => 'Invalid optional fields', 'errors' => ['fields' => $errors]], status: 400);
     }
 
+    /**
+     * @return array{optionalFields: array<string, string>} Metadados dos campos opcionais.
+     */
     public function options(): array
     {
         $fields = [];

--- a/packages/framework/src/Attributes/OptionalParams.php
+++ b/packages/framework/src/Attributes/OptionalParams.php
@@ -11,12 +11,27 @@ use Bifrost\Framework\Http\Response;
 use Bifrost\Framework\Validation\ValidationRule;
 
 #[Attribute(Attribute::TARGET_METHOD)]
+/**
+ * Declara parametros opcionais aceitos na query string.
+ *
+ * Parametros ausentes sao ignorados. Parametros presentes sao validados pela regra informada.
+ *
+ * Exemplo: #[OptionalParams(['search' => 'string', 'limit' => 'int-string'])]
+ */
 final class OptionalParams implements RequestValidatorAttribute
 {
+    /**
+     * @param array<string, mixed> $params Mapa de parametro opcional para regra de validacao.
+     */
     public function __construct(private readonly array $params)
     {
     }
 
+    /**
+     * Valida apenas os parametros opcionais presentes na query string.
+     *
+     * @return Response|null Retorna null quando os parametros presentes sao validos, ou resposta 400.
+     */
     public function validate(Request $request): ?Response
     {
         $errors = [];
@@ -43,6 +58,9 @@ final class OptionalParams implements RequestValidatorAttribute
         return Response::json(payload: ['message' => 'Invalid parameters', 'errors' => ['params' => $errors]], status: 400);
     }
 
+    /**
+     * @return array{optionalParams: array<string, string>} Metadados dos parametros opcionais.
+     */
     public function options(): array
     {
         $params = [];

--- a/packages/framework/src/Attributes/RequiredFields.php
+++ b/packages/framework/src/Attributes/RequiredFields.php
@@ -11,12 +11,29 @@ use Bifrost\Framework\Http\Response;
 use Bifrost\Framework\Validation\ValidationRule;
 
 #[Attribute(Attribute::TARGET_METHOD)]
+/**
+ * Declara campos obrigatorios no corpo da request.
+ *
+ * Aceita uma lista simples de nomes ou um mapa nome => regra.
+ * Regras podem ser tipos nomeados, DataTypes ou validadores callable.
+ *
+ * Exemplo: #[RequiredFields(['name' => 'string', 'email' => 'email'])]
+ */
 final class RequiredFields implements RequestValidatorAttribute
 {
+    /**
+     * @param array<int|string, mixed> $fields Campos obrigatorios. Use ['campo'] para aceitar qualquer valor
+     *                                        ou ['campo' => 'string'] para validar tipo/regra.
+     */
     public function __construct(private readonly array $fields)
     {
     }
 
+    /**
+     * Valida os campos obrigatorios no corpo JSON/form da request.
+     *
+     * @return Response|null Retorna null quando os campos sao validos, ou resposta 400 com erros por campo.
+     */
     public function validate(Request $request): ?Response
     {
         $errors = [];
@@ -45,6 +62,9 @@ final class RequiredFields implements RequestValidatorAttribute
         return Response::json(payload: ['message' => 'Invalid fields', 'errors' => ['fields' => $errors]], status: 400);
     }
 
+    /**
+     * @return array{fields: array<string, string>} Metadados dos campos obrigatorios.
+     */
     public function options(): array
     {
         return ['fields' => $this->describeFields()];

--- a/packages/framework/src/Attributes/RequiredParams.php
+++ b/packages/framework/src/Attributes/RequiredParams.php
@@ -11,12 +11,28 @@ use Bifrost\Framework\Http\Response;
 use Bifrost\Framework\Validation\ValidationRule;
 
 #[Attribute(Attribute::TARGET_METHOD)]
+/**
+ * Declara parametros obrigatorios na query string.
+ *
+ * Aceita uma lista simples de nomes ou um mapa nome => regra.
+ *
+ * Exemplo: #[RequiredParams(['page' => 'int-string', 'filter'])]
+ */
 final class RequiredParams implements RequestValidatorAttribute
 {
+    /**
+     * @param array<int|string, mixed> $params Parametros obrigatorios. Use ['param'] para aceitar qualquer valor
+     *                                        ou ['param' => 'string'] para validar tipo/regra.
+     */
     public function __construct(private readonly array $params)
     {
     }
 
+    /**
+     * Valida os parametros obrigatorios da query string.
+     *
+     * @return Response|null Retorna null quando os parametros sao validos, ou resposta 400.
+     */
     public function validate(Request $request): ?Response
     {
         $errors = [];
@@ -45,6 +61,9 @@ final class RequiredParams implements RequestValidatorAttribute
         return Response::json(payload: ['message' => 'Invalid parameters', 'errors' => ['params' => $errors]], status: 400);
     }
 
+    /**
+     * @return array{params: array<string, string>} Metadados dos parametros obrigatorios.
+     */
     public function options(): array
     {
         $params = [];

--- a/packages/framework/src/Attributes/Response.php
+++ b/packages/framework/src/Attributes/Response.php
@@ -8,12 +8,26 @@ use Attribute;
 use Bifrost\Framework\Contracts\HttpAttribute;
 
 #[Attribute(Attribute::TARGET_METHOD)]
+/**
+ * Descreve o formato esperado da resposta de uma action HTTP.
+ *
+ * O schema e livre para permitir documentacao simples ou integracao futura
+ * com geradores de contrato.
+ *
+ * Exemplo: #[Response(['status' => 200, 'body' => ['id' => 'int']])]
+ */
 final class Response implements HttpAttribute
 {
+    /**
+     * @param array<string, mixed> $schema Schema ou metadados da resposta.
+     */
     public function __construct(private readonly array $schema)
     {
     }
 
+    /**
+     * @return array{response: array<string, mixed>} Metadados da resposta.
+     */
     public function options(): array
     {
         return ['response' => $this->schema];

--- a/packages/framework/src/Attributes/Transaction.php
+++ b/packages/framework/src/Attributes/Transaction.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bifrost\Framework\Attributes;
+
+use Attribute;
+use Bifrost\Framework\Container;
+use Bifrost\Framework\Contracts\AfterResponseAttribute;
+use Bifrost\Framework\Contracts\BeforeRequestAttribute;
+use Bifrost\Framework\Contracts\TransactionManager;
+use Bifrost\Framework\Http\Request;
+use Bifrost\Framework\Http\Response;
+use RuntimeException;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+/**
+ * Envolve a action em uma transacao.
+ *
+ * Usa o TransactionManager registrado no container. Respostas 2xx confirmam a
+ * transacao; outras respostas fazem rollback.
+ */
+final class Transaction implements BeforeRequestAttribute, AfterResponseAttribute
+{
+    /**
+     * Inicia a transacao antes da action.
+     */
+    public function before(Request $request, Container $container): ?Response
+    {
+        $this->transactionManager($container)->begin();
+
+        return null;
+    }
+
+    /**
+     * Confirma ou desfaz a transacao conforme o status da resposta.
+     */
+    public function after(Request $request, Response $response, Container $container): ?Response
+    {
+        $transactionManager = $this->transactionManager($container);
+
+        if ($response->status() >= 200 && $response->status() < 300) {
+            $transactionManager->commit();
+            return null;
+        }
+
+        $transactionManager->rollback();
+
+        return null;
+    }
+
+    /**
+     * @return array{transaction: true}
+     */
+    public function options(): array
+    {
+        return ['transaction' => true];
+    }
+
+    private function transactionManager(Container $container): TransactionManager
+    {
+        if (!$container->has(TransactionManager::class)) {
+            throw new RuntimeException('TransactionManager nao foi registrado no container.');
+        }
+
+        $transactionManager = $container->get(TransactionManager::class);
+        if (!$transactionManager instanceof TransactionManager) {
+            throw new RuntimeException('TransactionManager registrado deve implementar Bifrost\\Framework\\Contracts\\TransactionManager.');
+        }
+
+        return $transactionManager;
+    }
+}

--- a/packages/framework/src/Container.php
+++ b/packages/framework/src/Container.php
@@ -6,6 +6,11 @@ namespace Bifrost\Framework;
 
 use RuntimeException;
 
+/**
+ * Container simples de dependencias da aplicacao.
+ *
+ * Permite registrar factories ou instancias e resolver objetos por identificador.
+ */
 final class Container
 {
     /** @var array<string, callable|object> */
@@ -14,23 +19,40 @@ final class Container
     /** @var array<string, object> */
     private array $instances = [];
 
+    /**
+     * Registra uma factory ou objeto para um identificador.
+     *
+     * @param string $id Identificador pesquisavel, normalmente a FQCN da interface/classe.
+     * @param callable|object $binding Factory que recebe o container ou objeto pronto.
+     */
     public function bind(string $id, callable|object $binding): void
     {
         $this->bindings[$id] = $binding;
         unset($this->instances[$id]);
     }
 
+    /**
+     * Registra uma instancia pronta para um identificador.
+     */
     public function instance(string $id, object $instance): void
     {
         $this->instances[$id] = $instance;
         unset($this->bindings[$id]);
     }
 
+    /**
+     * Verifica se existe binding ou instancia para o identificador.
+     */
     public function has(string $id): bool
     {
         return isset($this->bindings[$id]) || isset($this->instances[$id]);
     }
 
+    /**
+     * Resolve um objeto registrado no container.
+     *
+     * @throws RuntimeException Quando o servico nao existe ou nao resolve para objeto.
+     */
     public function get(string $id): object
     {
         if (isset($this->instances[$id])) {

--- a/packages/framework/src/Contracts/AfterResponseAttribute.php
+++ b/packages/framework/src/Contracts/AfterResponseAttribute.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bifrost\Framework\Contracts;
+
+use Bifrost\Framework\Container;
+use Bifrost\Framework\Http\Request;
+use Bifrost\Framework\Http\Response;
+
+/**
+ * Contrato para attributes executados depois da action do controller.
+ */
+interface AfterResponseAttribute extends HttpAttribute
+{
+    /**
+     * Executa logica apos a action.
+     *
+     * Retorne uma nova Response quando precisar substituir a resposta original.
+     */
+    public function after(Request $request, Response $response, Container $container): ?Response;
+}

--- a/packages/framework/src/Contracts/BeforeRequestAttribute.php
+++ b/packages/framework/src/Contracts/BeforeRequestAttribute.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bifrost\Framework\Contracts;
+
+use Bifrost\Framework\Container;
+use Bifrost\Framework\Http\Request;
+use Bifrost\Framework\Http\Response;
+
+/**
+ * Contrato para attributes executados antes da action do controller.
+ */
+interface BeforeRequestAttribute extends HttpAttribute
+{
+    /**
+     * Executa logica antes da action.
+     *
+     * @return Response|null Retorne Response para interromper o fluxo, ou null para continuar.
+     */
+    public function before(Request $request, Container $container): ?Response;
+}

--- a/packages/framework/src/Contracts/CacheStore.php
+++ b/packages/framework/src/Contracts/CacheStore.php
@@ -4,11 +4,25 @@ declare(strict_types=1);
 
 namespace Bifrost\Framework\Contracts;
 
+/**
+ * Contrato para stores de cache usados por extensoes do Bifrost.
+ */
 interface CacheStore
 {
+    /**
+     * Recupera um valor do cache ou null quando nao existir.
+     */
     public function get(string $key): mixed;
 
+    /**
+     * Armazena um valor no cache.
+     *
+     * @param int|null $ttlSeconds Tempo de vida em segundos. Null usa o padrao do provider.
+     */
     public function set(string $key, mixed $value, ?int $ttlSeconds = null): void;
 
+    /**
+     * Remove uma chave do cache.
+     */
     public function delete(string $key): void;
 }

--- a/packages/framework/src/Contracts/DataType.php
+++ b/packages/framework/src/Contracts/DataType.php
@@ -4,11 +4,26 @@ declare(strict_types=1);
 
 namespace Bifrost\Framework\Contracts;
 
+/**
+ * Contrato para objetos de valor com validacao propria.
+ *
+ * Use DataTypes quando um valor representa conceito do dominio e precisa de
+ * validacao, normalizacao ou tipagem forte em mais de um fluxo.
+ */
 interface DataType
 {
+    /**
+     * Cria o DataType a partir de um valor bruto validado.
+     */
     public static function from(mixed $value): static;
 
+    /**
+     * Verifica se um valor bruto pode ser aceito pelo DataType.
+     */
     public static function isValid(mixed $value): bool;
 
+    /**
+     * Retorna o valor primitivo armazenado.
+     */
     public function value(): mixed;
 }

--- a/packages/framework/src/Contracts/DatabaseConnectionFactory.php
+++ b/packages/framework/src/Contracts/DatabaseConnectionFactory.php
@@ -6,7 +6,15 @@ namespace Bifrost\Framework\Contracts;
 
 use PDO;
 
+/**
+ * Fabrica conexoes PDO nomeadas para pacotes de banco de dados.
+ */
 interface DatabaseConnectionFactory
 {
+    /**
+     * Retorna uma conexao PDO.
+     *
+     * @param string|null $name Nome da conexao. Null usa a conexao padrao.
+     */
     public function connection(?string $name = null): PDO;
 }

--- a/packages/framework/src/Contracts/Extension.php
+++ b/packages/framework/src/Contracts/Extension.php
@@ -6,7 +6,13 @@ namespace Bifrost\Framework\Contracts;
 
 use Bifrost\Framework\Application;
 
+/**
+ * Contrato para pacotes que registram servicos, rotas ou configuracoes na aplicacao.
+ */
 interface Extension
 {
+    /**
+     * Registra a extensao na aplicacao Bifrost.
+     */
     public function register(Application $application): void;
 }

--- a/packages/framework/src/Contracts/HttpAttribute.php
+++ b/packages/framework/src/Contracts/HttpAttribute.php
@@ -4,7 +4,13 @@ declare(strict_types=1);
 
 namespace Bifrost\Framework\Contracts;
 
+/**
+ * Contrato base para attributes HTTP que expõem metadados do endpoint.
+ */
 interface HttpAttribute
 {
+    /**
+     * @return array<string, mixed> Metadados usados por OPTIONS ou documentacao.
+     */
     public function options(): array;
 }

--- a/packages/framework/src/Contracts/LogWriter.php
+++ b/packages/framework/src/Contracts/LogWriter.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bifrost\Framework\Contracts;
+
+/**
+ * Contrato generico para escritores de log.
+ */
+interface LogWriter
+{
+    /**
+     * Persiste uma entrada de log estruturada.
+     *
+     * @param array<string, mixed> $entry Entrada de log serializavel.
+     */
+    public function write(array $entry): void;
+}

--- a/packages/framework/src/Contracts/Queue.php
+++ b/packages/framework/src/Contracts/Queue.php
@@ -4,9 +4,22 @@ declare(strict_types=1);
 
 namespace Bifrost\Framework\Contracts;
 
+/**
+ * Contrato para adaptadores de fila.
+ */
 interface Queue
 {
+    /**
+     * Publica uma mensagem em uma fila.
+     *
+     * @param array<string, mixed> $payload Dados serializaveis da mensagem.
+     */
     public function push(string $queue, array $payload): void;
 
+    /**
+     * Consome uma mensagem da fila.
+     *
+     * @return array<string, mixed>|null Payload da mensagem ou null quando nao houver item.
+     */
     public function pop(string $queue): ?array;
 }

--- a/packages/framework/src/Contracts/RequestValidatorAttribute.php
+++ b/packages/framework/src/Contracts/RequestValidatorAttribute.php
@@ -7,7 +7,15 @@ namespace Bifrost\Framework\Contracts;
 use Bifrost\Framework\Http\Request;
 use Bifrost\Framework\Http\Response;
 
+/**
+ * Contrato para attributes que validam uma request antes da action do controller.
+ */
 interface RequestValidatorAttribute extends HttpAttribute
 {
+    /**
+     * Valida a request atual.
+     *
+     * @return Response|null Retorne null para permitir a action, ou Response para interromper o fluxo.
+     */
     public function validate(Request $request): ?Response;
 }

--- a/packages/framework/src/Contracts/Storage.php
+++ b/packages/framework/src/Contracts/Storage.php
@@ -6,14 +6,41 @@ namespace Bifrost\Framework\Contracts;
 
 use DateTimeImmutable;
 
+/**
+ * Contrato para storage de arquivos independente de provider.
+ */
 interface Storage
 {
+    /**
+     * Salva um corpo em uma chave/caminho.
+     *
+     * @param array<string, mixed> $options Opcoes especificas do provider.
+     * @return array<string, mixed> Metadados do arquivo salvo.
+     */
     public function put(string $key, string $body, array $options = []): array;
 
+    /**
+     * Recupera um arquivo por chave/caminho.
+     *
+     * @param array<string, mixed> $options Opcoes especificas do provider.
+     * @return array<string, mixed> Metadados e conteudo conforme implementacao.
+     */
     public function get(string $key, array $options = []): array;
 
+    /**
+     * Remove um arquivo por chave/caminho.
+     *
+     * @param array<string, mixed> $options Opcoes especificas do provider.
+     * @return array<string, mixed> Metadados da remocao.
+     */
     public function delete(string $key, array $options = []): array;
 
+    /**
+     * Gera uma URL temporaria para acesso ao arquivo.
+     *
+     * @param DateTimeImmutable|null $expiresAt Data de expiracao. Null usa o padrao do provider.
+     * @param array<string, mixed> $options Opcoes especificas do provider.
+     */
     public function temporaryUrl(
         string $key,
         ?DateTimeImmutable $expiresAt = null,

--- a/packages/framework/src/Contracts/TransactionManager.php
+++ b/packages/framework/src/Contracts/TransactionManager.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bifrost\Framework\Contracts;
+
+/**
+ * Contrato minimo para controle transacional usado por attributes e extensoes.
+ */
+interface TransactionManager
+{
+    /**
+     * Inicia uma transacao.
+     */
+    public function begin(): bool;
+
+    /**
+     * Confirma a transacao aberta.
+     */
+    public function commit(): bool;
+
+    /**
+     * Desfaz a transacao aberta.
+     */
+    public function rollback(): bool;
+}

--- a/packages/framework/src/Exceptions/HttpException.php
+++ b/packages/framework/src/Exceptions/HttpException.php
@@ -6,8 +6,18 @@ namespace Bifrost\Framework\Exceptions;
 
 use RuntimeException;
 
+/**
+ * Excecao HTTP padronizada para respostas JSON.
+ *
+ * Use quando o dominio ou uma camada de aplicacao precisa interromper o fluxo
+ * com status, erros e headers controlados.
+ */
 final class HttpException extends RuntimeException
 {
+    /**
+     * @param array<string, mixed> $errors Erros seguros para retornar ao cliente.
+     * @param array<string, string> $headers Headers adicionais da resposta.
+     */
     public function __construct(
         string $message,
         private readonly int $status = 500,
@@ -17,31 +27,56 @@ final class HttpException extends RuntimeException
         parent::__construct($message);
     }
 
+    /**
+     * Cria uma excecao 400 Bad Request.
+     *
+     * @param array<string, mixed> $errors Erros seguros para retornar ao cliente.
+     * @param array<string, string> $headers Headers adicionais.
+     */
     public static function badRequest(string $message = 'Bad Request', array $errors = [], array $headers = []): self
     {
         return new self(message: $message, status: 400, errors: $errors, headers: $headers);
     }
 
+    /**
+     * Cria uma excecao 404 Not Found.
+     *
+     * @param array<string, string> $headers Headers adicionais.
+     */
     public static function notFound(string $message = 'Not Found', array $headers = []): self
     {
         return new self(message: $message, status: 404, headers: $headers);
     }
 
+    /**
+     * Cria uma excecao 500 Internal Server Error.
+     *
+     * @param array<string, string> $headers Headers adicionais.
+     */
     public static function internalServerError(string $message = 'Internal Server Error', array $headers = []): self
     {
         return new self(message: $message, status: 500, headers: $headers);
     }
 
+    /**
+     * Retorna o status HTTP que sera usado na resposta.
+     */
     public function status(): int
     {
         return $this->status;
     }
 
+    /**
+     * @return array<string, mixed> Erros seguros para retornar ao cliente.
+     */
     public function errors(): array
     {
         return $this->errors;
     }
 
+    /**
+     * @return array<string, string> Headers adicionais da resposta.
+     */
     public function headers(): array
     {
         return $this->headers;

--- a/packages/framework/src/Http/HttpKernel.php
+++ b/packages/framework/src/Http/HttpKernel.php
@@ -10,6 +10,12 @@ use Bifrost\Framework\Routing\Router;
 use JsonException;
 use Throwable;
 
+/**
+ * Executa o lifecycle HTTP da aplicacao.
+ *
+ * Aplica middlewares, resolve rotas, converte resultados de controllers em Response
+ * e padroniza respostas de erro com X-Request-Id.
+ */
 final class HttpKernel
 {
     /** @var list<callable> */
@@ -22,11 +28,19 @@ final class HttpKernel
     ) {
     }
 
+    /**
+     * Registra um middleware no pipeline HTTP.
+     *
+     * O callable recebe Request e next callable, e deve retornar Response.
+     */
     public function middleware(callable $middleware): void
     {
         $this->middleware[] = $middleware;
     }
 
+    /**
+     * Processa uma request completa e sempre retorna uma Response.
+     */
     public function handle(Request $request): Response
     {
         $dispatcher = fn (Request $incoming): Response => $this->dispatch($incoming);

--- a/packages/framework/src/Http/HttpStatusCode.php
+++ b/packages/framework/src/Http/HttpStatusCode.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bifrost\Framework\Http;
+
+/**
+ * Codigos HTTP comuns usados pelo framework.
+ */
+enum HttpStatusCode: int
+{
+    case OK = 200;
+    case CREATED = 201;
+    case ACCEPTED = 202;
+    case NO_CONTENT = 204;
+    case MOVED_PERMANENTLY = 301;
+    case FOUND = 302;
+    case NOT_MODIFIED = 304;
+    case BAD_REQUEST = 400;
+    case UNAUTHORIZED = 401;
+    case FORBIDDEN = 403;
+    case NOT_FOUND = 404;
+    case METHOD_NOT_ALLOWED = 405;
+    case CONFLICT = 409;
+    case INTERNAL_SERVER_ERROR = 500;
+    case NOT_IMPLEMENTED = 501;
+    case BAD_GATEWAY = 502;
+    case SERVICE_UNAVAILABLE = 503;
+
+    /**
+     * Retorna a mensagem padrao do status HTTP.
+     */
+    public function message(): string
+    {
+        return match ($this) {
+            self::OK => 'OK',
+            self::CREATED => 'Created',
+            self::ACCEPTED => 'Accepted',
+            self::NO_CONTENT => 'No Content',
+            self::MOVED_PERMANENTLY => 'Moved Permanently',
+            self::FOUND => 'Found',
+            self::NOT_MODIFIED => 'Not Modified',
+            self::BAD_REQUEST => 'Bad Request',
+            self::UNAUTHORIZED => 'Unauthorized',
+            self::FORBIDDEN => 'Forbidden',
+            self::NOT_FOUND => 'Not Found',
+            self::METHOD_NOT_ALLOWED => 'Method Not Allowed',
+            self::CONFLICT => 'Conflict',
+            self::INTERNAL_SERVER_ERROR => 'Internal Server Error',
+            self::NOT_IMPLEMENTED => 'Not Implemented',
+            self::BAD_GATEWAY => 'Bad Gateway',
+            self::SERVICE_UNAVAILABLE => 'Service Unavailable',
+        };
+    }
+
+    /**
+     * Indica se o status representa sucesso.
+     */
+    public function isSuccess(): bool
+    {
+        return $this->value >= 200 && $this->value < 300;
+    }
+
+    /**
+     * Indica se o status representa redirecionamento.
+     */
+    public function isRedirection(): bool
+    {
+        return $this->value >= 300 && $this->value < 400;
+    }
+
+    /**
+     * Indica se o status representa erro do cliente.
+     */
+    public function isClientError(): bool
+    {
+        return $this->value >= 400 && $this->value < 500;
+    }
+
+    /**
+     * Indica se o status representa erro do servidor.
+     */
+    public function isServerError(): bool
+    {
+        return $this->value >= 500;
+    }
+}

--- a/packages/framework/src/Http/Request.php
+++ b/packages/framework/src/Http/Request.php
@@ -4,11 +4,25 @@ declare(strict_types=1);
 
 namespace Bifrost\Framework\Http;
 
+/**
+ * Representa a request HTTP normalizada pelo Bifrost.
+ *
+ * Fornece acesso ao metodo, path, query string, corpo da request, headers e request-id.
+ * Controllers recebem esta classe como entrada principal.
+ */
 final class Request
 {
     private readonly array $headers;
     private readonly string $requestId;
 
+    /**
+     * @param string $method Metodo HTTP recebido.
+     * @param string $path Path da request, com ou sem barra inicial.
+     * @param array<string, mixed> $query Parametros de query string.
+     * @param array<string, mixed> $body Corpo decodificado da request.
+     * @param array<string, string> $headers Headers HTTP.
+     * @param string|null $requestId Identificador da request. Se omitido, usa X-Request-Id ou gera um novo.
+     */
     public function __construct(
         private readonly string $method,
         private readonly string $path,
@@ -21,6 +35,9 @@ final class Request
         $this->requestId = self::resolveRequestId($this->headers, $requestId);
     }
 
+    /**
+     * Cria uma request a partir das variaveis globais do PHP.
+     */
     public static function fromGlobals(): self
     {
         $method = strtoupper((string) ($_SERVER['REQUEST_METHOD'] ?? 'GET'));
@@ -39,11 +56,17 @@ final class Request
         );
     }
 
+    /**
+     * Retorna o metodo HTTP em maiusculas.
+     */
     public function method(): string
     {
         return strtoupper($this->method);
     }
 
+    /**
+     * Retorna o path normalizado, sempre com barra inicial e sem barra final.
+     */
     public function path(): string
     {
         $path = '/' . ltrim($this->path, '/');
@@ -51,21 +74,44 @@ final class Request
         return $path !== '/' ? rtrim($path, '/') : $path;
     }
 
+    /**
+     * Le parametros da query string.
+     *
+     * @param string|null $key Nome do parametro. Quando null, retorna todos os parametros.
+     * @param mixed $default Valor usado quando o parametro nao existe.
+     * @return mixed Valor do parametro, todos os parametros ou o default.
+     */
     public function query(?string $key = null, mixed $default = null): mixed
     {
         return $key === null ? $this->query : ($this->query[$key] ?? $default);
     }
 
+    /**
+     * Le valores do corpo da request.
+     *
+     * @param string|null $key Nome do campo. Quando null, retorna todo o corpo.
+     * @param mixed $default Valor usado quando o campo nao existe.
+     * @return mixed Valor do campo, corpo completo ou o default.
+     */
     public function input(?string $key = null, mixed $default = null): mixed
     {
         return $key === null ? $this->body : ($this->body[$key] ?? $default);
     }
 
+    /**
+     * Le um header HTTP por nome, sem diferenciar maiusculas/minusculas.
+     *
+     * @param string $name Nome do header, como Authorization ou X-Request-Id.
+     * @param string|null $default Valor usado quando o header nao existe.
+     */
     public function header(string $name, ?string $default = null): ?string
     {
         return $this->headers[strtolower($name)] ?? $default;
     }
 
+    /**
+     * Retorna o identificador da request para rastreamento.
+     */
     public function requestId(): string
     {
         return $this->requestId;

--- a/packages/framework/src/Http/Response.php
+++ b/packages/framework/src/Http/Response.php
@@ -6,8 +6,19 @@ namespace Bifrost\Framework\Http;
 
 use JsonException;
 
+/**
+ * Representa uma resposta HTTP imutavel.
+ *
+ * Use os factories como json(), created(), badRequest() e text() para construir
+ * respostas de controller com status e headers consistentes.
+ */
 final class Response
 {
+    /**
+     * @param string $body Corpo bruto da resposta.
+     * @param int $status Codigo HTTP da resposta.
+     * @param array<string, string> $headers Headers HTTP da resposta.
+     */
     public function __construct(
         private readonly string $body = '',
         private readonly int $status = 200,
@@ -16,6 +27,11 @@ final class Response
     }
 
     /**
+     * Cria uma resposta JSON.
+     *
+     * @param array<string, mixed> $payload Payload serializado para JSON.
+     * @param int $status Codigo HTTP da resposta.
+     * @param array<string, string> $headers Headers adicionais.
      * @throws JsonException
      */
     public static function json(array $payload, int $status = 200, array $headers = []): self
@@ -30,6 +46,10 @@ final class Response
     }
 
     /**
+     * Cria uma resposta JSON 201 Created.
+     *
+     * @param array<string, mixed> $payload Payload serializado para JSON.
+     * @param array<string, string> $headers Headers adicionais.
      * @throws JsonException
      */
     public static function created(array $payload = [], array $headers = []): self
@@ -38,6 +58,10 @@ final class Response
     }
 
     /**
+     * Cria uma resposta JSON 400 Bad Request.
+     *
+     * @param array<string, mixed> $errors Erros de validacao ou detalhes seguros para o cliente.
+     * @param array<string, string> $headers Headers adicionais.
      * @throws JsonException
      */
     public static function badRequest(string $message = 'Bad Request', array $errors = [], array $headers = []): self
@@ -51,6 +75,9 @@ final class Response
     }
 
     /**
+     * Cria uma resposta JSON 404 Not Found.
+     *
+     * @param array<string, string> $headers Headers adicionais.
      * @throws JsonException
      */
     public static function notFound(string $message = 'Not Found', array $headers = []): self
@@ -59,6 +86,9 @@ final class Response
     }
 
     /**
+     * Cria uma resposta JSON 500 Internal Server Error.
+     *
+     * @param array<string, string> $headers Headers adicionais.
      * @throws JsonException
      */
     public static function internalServerError(string $message = 'Internal Server Error', array $headers = []): self
@@ -66,6 +96,11 @@ final class Response
         return self::json(payload: ['message' => $message], status: 500, headers: $headers);
     }
 
+    /**
+     * Cria uma resposta de texto puro.
+     *
+     * @param array<string, string> $headers Headers adicionais.
+     */
     public static function text(string $body, int $status = 200, array $headers = []): self
     {
         $headers['Content-Type'] ??= 'text/plain; charset=utf-8';
@@ -73,6 +108,9 @@ final class Response
         return new self(body: $body, status: $status, headers: $headers);
     }
 
+    /**
+     * Retorna uma nova resposta com o header informado.
+     */
     public function withHeader(string $name, string $value): self
     {
         return new self(
@@ -82,21 +120,33 @@ final class Response
         );
     }
 
+    /**
+     * Retorna uma nova resposta com outro corpo.
+     */
     public function withBody(string $body): self
     {
         return new self(body: $body, status: $this->status, headers: $this->headers);
     }
 
+    /**
+     * Retorna o corpo bruto da resposta.
+     */
     public function body(): string
     {
         return $this->body;
     }
 
+    /**
+     * Retorna o codigo HTTP da resposta.
+     */
     public function status(): int
     {
         return $this->status;
     }
 
+    /**
+     * @return array<string, string> Headers HTTP da resposta.
+     */
     public function headers(): array
     {
         return $this->headers;

--- a/packages/framework/src/Http/ResponseEmitter.php
+++ b/packages/framework/src/Http/ResponseEmitter.php
@@ -4,8 +4,14 @@ declare(strict_types=1);
 
 namespace Bifrost\Framework\Http;
 
+/**
+ * Envia uma Response para o runtime HTTP do PHP.
+ */
 final class ResponseEmitter
 {
+    /**
+     * Define status, headers e imprime o corpo da resposta.
+     */
     public function emit(Response $response): void
     {
         http_response_code($response->status());

--- a/packages/framework/src/Logging/Logger.php
+++ b/packages/framework/src/Logging/Logger.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bifrost\Framework\Logging;
+
+use Bifrost\Framework\Contracts\LogWriter;
+use Closure;
+use Throwable;
+
+/**
+ * Logger estruturado que depende apenas de um LogWriter.
+ *
+ * O framework nao escolhe destino de log. Pacotes opcionais registram o writer
+ * concreto e podem expor esta classe no container.
+ */
+final class Logger
+{
+    /** @var Closure(): string */
+    private readonly Closure $timestampResolver;
+
+    /** @var Closure(): string */
+    private readonly Closure $requestIdResolver;
+
+    public function __construct(
+        private readonly LogWriter $writer,
+        ?callable $timestampResolver = null,
+        ?callable $requestIdResolver = null
+    ) {
+        $this->timestampResolver = Closure::fromCallable($timestampResolver ?? static fn (): string => gmdate('c'));
+        $this->requestIdResolver = Closure::fromCallable($requestIdResolver ?? self::defaultRequestIdResolver());
+    }
+
+    /**
+     * @param array<string, mixed> $context Contexto seguro para persistir no log.
+     */
+    public function debug(string $message, array $context = []): void
+    {
+        $this->write('debug', $message, $context);
+    }
+
+    /**
+     * @param array<string, mixed> $context Contexto seguro para persistir no log.
+     */
+    public function info(string $message, array $context = []): void
+    {
+        $this->write('info', $message, $context);
+    }
+
+    /**
+     * @param array<string, mixed> $context Contexto seguro para persistir no log.
+     */
+    public function warning(string $message, array $context = []): void
+    {
+        $this->write('warning', $message, $context);
+    }
+
+    /**
+     * @param array<string, mixed> $context Contexto seguro para persistir no log.
+     */
+    public function error(string $message, array $context = []): void
+    {
+        $this->write('error', $message, $context);
+    }
+
+    /**
+     * Registra uma excecao sem copiar a mensagem automaticamente para evitar vazamento de dados sensiveis.
+     *
+     * @param array<string, mixed> $context Contexto seguro para persistir no log.
+     */
+    public function exception(Throwable $exception, array $context = []): void
+    {
+        $this->error('Unhandled exception', array_merge($context, [
+            'exception' => [
+                'class' => $exception::class,
+                'code' => $exception->getCode(),
+            ],
+        ]));
+    }
+
+    /**
+     * @param array<string, mixed> $context Contexto seguro para persistir no log.
+     */
+    public function write(string $level, string $message, array $context = []): void
+    {
+        $this->writer->write([
+            'timestamp' => ($this->timestampResolver)(),
+            'level' => $level,
+            'message' => $message,
+            'request_id' => ($this->requestIdResolver)(),
+            'context' => $context,
+        ]);
+    }
+
+    /**
+     * @return Closure(): string
+     */
+    private static function defaultRequestIdResolver(): Closure
+    {
+        $requestId = null;
+
+        return static function () use (&$requestId): string {
+            if ($requestId !== null) {
+                return $requestId;
+            }
+
+            $header = $_SERVER['HTTP_X_REQUEST_ID'] ?? null;
+            if (is_string($header) && trim($header) !== '') {
+                return $requestId = trim($header);
+            }
+
+            return $requestId = bin2hex(random_bytes(16));
+        };
+    }
+}

--- a/packages/framework/src/Routing/ControllerResolver.php
+++ b/packages/framework/src/Routing/ControllerResolver.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Bifrost\Framework\Routing;
 
 use Bifrost\Framework\Container;
+use Bifrost\Framework\Contracts\AfterResponseAttribute;
+use Bifrost\Framework\Contracts\BeforeRequestAttribute;
 use Bifrost\Framework\Contracts\HttpAttribute;
 use Bifrost\Framework\Contracts\RequestValidatorAttribute;
 use Bifrost\Framework\Http\Request;
@@ -12,12 +14,26 @@ use Bifrost\Framework\Http\Response;
 use ReflectionMethod;
 use RuntimeException;
 
+/**
+ * Resolve e executa handlers de rota.
+ *
+ * Tambem aplica validators declarados por attributes antes de chamar a action.
+ */
 final class ControllerResolver
 {
+    /**
+     * @param Container $container Container usado para resolver controllers registrados.
+     */
     public function __construct(private readonly Container $container)
     {
     }
 
+    /**
+     * Executa um handler de rota.
+     *
+     * @param mixed $handler Callable ou par [Controller::class, 'metodo'].
+     * @return mixed Resultado bruto da action/callable.
+     */
     public function invoke(mixed $handler, Request $request): mixed
     {
         if (is_array($handler) && isset($handler[0], $handler[1]) && is_string($handler[0])) {
@@ -25,12 +41,20 @@ final class ControllerResolver
                 ? $this->container->get($handler[0])
                 : new $handler[0]();
 
-            $validationResponse = $this->validateAttributes($controller, (string) $handler[1], $request);
+            $method = (string) $handler[1];
+            $validationResponse = $this->validateAttributes($controller, $method, $request);
             if ($validationResponse instanceof Response) {
                 return $validationResponse;
             }
 
-            return $controller->{$handler[1]}($request);
+            $beforeResponse = $this->runBeforeAttributes($controller, $method, $request);
+            if ($beforeResponse instanceof Response) {
+                return $beforeResponse;
+            }
+
+            $result = $controller->{$method}($request);
+
+            return $this->runAfterAttributes($controller, $method, $request, $result);
         }
 
         if (is_callable($handler)) {
@@ -40,6 +64,12 @@ final class ControllerResolver
         throw new RuntimeException('Handler de rota invalido.');
     }
 
+    /**
+     * Retorna metadados dos attributes HTTP de uma action.
+     *
+     * @param mixed $handler Par [Controller::class, 'metodo'].
+     * @return array<string, mixed>
+     */
     public function options(mixed $handler): array
     {
         if (!is_array($handler) || !isset($handler[0], $handler[1]) || !is_string($handler[0])) {
@@ -82,5 +112,59 @@ final class ControllerResolver
         }
 
         return null;
+    }
+
+    private function runBeforeAttributes(object $controller, string $method, Request $request): ?Response
+    {
+        $reflection = new ReflectionMethod($controller, $method);
+
+        foreach ($reflection->getAttributes() as $attribute) {
+            $instance = $attribute->newInstance();
+            if (!$instance instanceof BeforeRequestAttribute) {
+                continue;
+            }
+
+            $response = $instance->before($request, $this->container);
+            if ($response instanceof Response) {
+                return $response;
+            }
+        }
+
+        return null;
+    }
+
+    private function runAfterAttributes(object $controller, string $method, Request $request, mixed $result): mixed
+    {
+        $reflection = new ReflectionMethod($controller, $method);
+        $attributes = array_reverse($reflection->getAttributes());
+        $response = null;
+
+        foreach ($attributes as $attribute) {
+            $instance = $attribute->newInstance();
+            if (!$instance instanceof AfterResponseAttribute) {
+                continue;
+            }
+
+            $response ??= $this->responseFromResult($result);
+            $replacement = $instance->after($request, $response, $this->container);
+            if ($replacement instanceof Response) {
+                $response = $replacement;
+            }
+        }
+
+        return $response ?? $result;
+    }
+
+    private function responseFromResult(mixed $result): Response
+    {
+        if ($result instanceof Response) {
+            return $result;
+        }
+
+        if (is_array($result)) {
+            return Response::json(payload: $result);
+        }
+
+        return Response::text((string) $result);
     }
 }

--- a/packages/framework/src/Routing/Route.php
+++ b/packages/framework/src/Routing/Route.php
@@ -4,8 +4,14 @@ declare(strict_types=1);
 
 namespace Bifrost\Framework\Routing;
 
+/**
+ * Representa uma rota HTTP registrada no router.
+ */
 final class Route
 {
+    /**
+     * @param mixed $handler Callable ou par [Controller::class, 'metodo'].
+     */
     public function __construct(
         private readonly string $method,
         private readonly string $path,
@@ -13,16 +19,27 @@ final class Route
     ) {
     }
 
+    /**
+     * Retorna o metodo HTTP da rota.
+     */
     public function method(): string
     {
         return $this->method;
     }
 
+    /**
+     * Retorna o path normalizado da rota.
+     */
     public function path(): string
     {
         return $this->path;
     }
 
+    /**
+     * Retorna o handler da rota.
+     *
+     * @return mixed Callable ou par [Controller::class, 'metodo'].
+     */
     public function handler(): mixed
     {
         return $this->handler;

--- a/packages/framework/src/Routing/Router.php
+++ b/packages/framework/src/Routing/Router.php
@@ -6,11 +6,19 @@ namespace Bifrost\Framework\Routing;
 
 use Bifrost\Framework\Http\Request;
 
+/**
+ * Registro e busca de rotas HTTP.
+ */
 final class Router
 {
     /** @var array<string, array<string, Route>> */
     private array $routes = [];
 
+    /**
+     * Registra uma rota.
+     *
+     * @param mixed $handler Callable ou par [Controller::class, 'metodo'].
+     */
     public function add(string $method, string $path, mixed $handler): void
     {
         $method = strtoupper($method);
@@ -18,16 +26,27 @@ final class Router
         $this->routes[$path][$method] = new Route(method: $method, path: $path, handler: $handler);
     }
 
+    /**
+     * Busca a rota exata para method/path da request.
+     */
     public function match(Request $request): ?Route
     {
         return $this->routes[$request->path()][$request->method()] ?? null;
     }
 
+    /**
+     * Retorna os metodos permitidos para um path.
+     *
+     * @return list<string>
+     */
     public function allowedMethods(string $path): array
     {
         return array_keys($this->routes[self::normalizePath($path)] ?? []);
     }
 
+    /**
+     * Retorna a primeira rota registrada para um path, independente do metodo.
+     */
     public function firstRouteForPath(string $path): ?Route
     {
         $routes = $this->routes[self::normalizePath($path)] ?? [];

--- a/packages/framework/src/Validation/ValidationRule.php
+++ b/packages/framework/src/Validation/ValidationRule.php
@@ -6,8 +6,21 @@ namespace Bifrost\Framework\Validation;
 
 use Bifrost\Framework\Contracts\DataType;
 
+/**
+ * Valida valores usados pelos attributes de request.
+ *
+ * Aceita regras nomeadas, DataTypes ou callables.
+ */
 final class ValidationRule
 {
+    /**
+     * Verifica se um valor atende a uma regra.
+     *
+     * Regras nomeadas suportadas: int, int-string, string, float, numeric, bool,
+     * array, object, null, email, url, base64, json e uuid.
+     *
+     * @param mixed $rule Nome da regra, classe DataType, instancia DataType ou callable.
+     */
     public static function validate(mixed $value, mixed $rule): bool
     {
         if (is_string($rule) && enum_exists($rule) === false && class_exists($rule) === false) {
@@ -29,6 +42,9 @@ final class ValidationRule
         return false;
     }
 
+    /**
+     * Descreve uma regra em formato legivel para metadados de endpoint.
+     */
     public static function describe(mixed $rule): string
     {
         if (is_string($rule)) {

--- a/packages/framework/tests/AttributeHooksTest.php
+++ b/packages/framework/tests/AttributeHooksTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bifrost\Framework\Tests;
+
+use Bifrost\Framework\Application;
+use Bifrost\Framework\Attributes\Cache;
+use Bifrost\Framework\Attributes\Transaction;
+use Bifrost\Framework\Contracts\CacheStore;
+use Bifrost\Framework\Contracts\TransactionManager;
+use Bifrost\Framework\Http\HttpStatusCode;
+use Bifrost\Framework\Http\Request;
+use Bifrost\Framework\Http\Response;
+use PHPUnit\Framework\TestCase;
+
+final class AttributeHooksTest extends TestCase
+{
+    public function testCacheAttributeReusesStoredResponse(): void
+    {
+        $application = Application::create();
+        $cache = new InMemoryCacheStore();
+        $application->container()->instance(CacheStore::class, $cache);
+        $application->get('/cached', [CacheControllerStub::class, 'show']);
+
+        $first = $application->handle(new Request(method: 'GET', path: '/cached'));
+        $second = $application->handle(new Request(method: 'GET', path: '/cached'));
+
+        self::assertSame('{"count":1}', $first->body());
+        self::assertSame('{"count":1}', $second->body());
+        self::assertCount(1, $cache->values);
+    }
+
+    public function testTransactionAttributeCommitsSuccessfulResponse(): void
+    {
+        $application = Application::create();
+        $transactionManager = new RecordingTransactionManager();
+        $application->container()->instance(TransactionManager::class, $transactionManager);
+        $application->post('/transaction', [TransactionControllerStub::class, 'store']);
+
+        $response = $application->handle(new Request(method: 'POST', path: '/transaction'));
+
+        self::assertSame(201, $response->status());
+        self::assertSame(['begin', 'commit'], $transactionManager->events);
+    }
+
+    public function testTransactionAttributeRollsBackErrorResponse(): void
+    {
+        $application = Application::create();
+        $transactionManager = new RecordingTransactionManager();
+        $application->container()->instance(TransactionManager::class, $transactionManager);
+        $application->post('/transaction/fail', [TransactionControllerStub::class, 'fail']);
+
+        $response = $application->handle(new Request(method: 'POST', path: '/transaction/fail'));
+
+        self::assertSame(400, $response->status());
+        self::assertSame(['begin', 'rollback'], $transactionManager->events);
+    }
+
+    public function testHttpStatusCodeClassifiesStatusFamilies(): void
+    {
+        self::assertSame('Created', HttpStatusCode::CREATED->message());
+        self::assertTrue(HttpStatusCode::CREATED->isSuccess());
+        self::assertTrue(HttpStatusCode::FOUND->isRedirection());
+        self::assertTrue(HttpStatusCode::BAD_REQUEST->isClientError());
+        self::assertTrue(HttpStatusCode::INTERNAL_SERVER_ERROR->isServerError());
+    }
+}
+
+final class CacheControllerStub
+{
+    private static int $count = 0;
+
+    #[Cache(seconds: 60)]
+    public function show(Request $request): Response
+    {
+        self::$count++;
+
+        return Response::json(['count' => self::$count]);
+    }
+}
+
+final class TransactionControllerStub
+{
+    #[Transaction]
+    public function store(Request $request): Response
+    {
+        return Response::created(['created' => true]);
+    }
+
+    #[Transaction]
+    public function fail(Request $request): Response
+    {
+        return Response::badRequest('Invalid payload');
+    }
+}
+
+final class InMemoryCacheStore implements CacheStore
+{
+    /** @var array<string, mixed> */
+    public array $values = [];
+
+    public function get(string $key): mixed
+    {
+        return $this->values[$key] ?? null;
+    }
+
+    public function set(string $key, mixed $value, ?int $ttlSeconds = null): void
+    {
+        $this->values[$key] = $value;
+    }
+
+    public function delete(string $key): void
+    {
+        unset($this->values[$key]);
+    }
+}
+
+final class RecordingTransactionManager implements TransactionManager
+{
+    /** @var list<string> */
+    public array $events = [];
+
+    public function begin(): bool
+    {
+        $this->events[] = 'begin';
+
+        return true;
+    }
+
+    public function commit(): bool
+    {
+        $this->events[] = 'commit';
+
+        return true;
+    }
+
+    public function rollback(): bool
+    {
+        $this->events[] = 'rollback';
+
+        return true;
+    }
+}

--- a/packages/framework/tests/LoggerTest.php
+++ b/packages/framework/tests/LoggerTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bifrost\Framework\Tests;
+
+use Bifrost\Framework\Contracts\LogWriter;
+use Bifrost\Framework\Logging\Logger;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+final class LoggerTest extends TestCase
+{
+    public function testWritesStructuredLogEntry(): void
+    {
+        $writer = new RecordingLogWriter();
+        $logger = new Logger(
+            writer: $writer,
+            timestampResolver: static fn (): string => '2026-05-28T12:00:00+00:00',
+            requestIdResolver: static fn (): string => 'req-123'
+        );
+
+        $logger->info('Requisicao recebida', ['route' => '/health']);
+
+        self::assertSame([[
+            'timestamp' => '2026-05-28T12:00:00+00:00',
+            'level' => 'info',
+            'message' => 'Requisicao recebida',
+            'request_id' => 'req-123',
+            'context' => ['route' => '/health'],
+        ]], $writer->entries);
+    }
+
+    public function testWritesExceptionShapeWithoutSensitiveMessage(): void
+    {
+        $writer = new RecordingLogWriter();
+        $logger = new Logger(
+            writer: $writer,
+            timestampResolver: static fn (): string => '2026-05-28T12:00:00+00:00',
+            requestIdResolver: static fn (): string => 'req-123'
+        );
+
+        $logger->exception(new RuntimeException('senha=secret', 500), ['operation' => 'store']);
+
+        self::assertSame('error', $writer->entries[0]['level']);
+        self::assertSame('Unhandled exception', $writer->entries[0]['message']);
+        self::assertSame(RuntimeException::class, $writer->entries[0]['context']['exception']['class']);
+        self::assertSame(500, $writer->entries[0]['context']['exception']['code']);
+        self::assertStringNotContainsString('secret', json_encode($writer->entries[0], JSON_THROW_ON_ERROR));
+    }
+}
+
+final class RecordingLogWriter implements LogWriter
+{
+    /** @var list<array<string, mixed>> */
+    public array $entries = [];
+
+    public function write(array $entry): void
+    {
+        $this->entries[] = $entry;
+    }
+}

--- a/packages/log-file/README.md
+++ b/packages/log-file/README.md
@@ -1,0 +1,31 @@
+# bifrost/log-file
+
+Pacote opcional de logs em arquivo para o Bifrost Framework.
+
+```php
+use Bifrost\Extension\LogFile\FileLogExtension;
+use Bifrost\Framework\Logging\Logger;
+
+$application->extend(new FileLogExtension([
+    'path' => __DIR__ . '/../storage/logs/app.log',
+]));
+
+$application->container()
+    ->get(Logger::class)
+    ->info('Requisicao recebida', ['route' => '/health']);
+```
+
+Cada entrada e gravada como uma linha JSON com o formato:
+
+```php
+[
+    'timestamp' => gmdate('c'),
+    'level' => 'info',
+    'message' => 'Requisicao recebida',
+    'request_id' => '...',
+    'context' => [],
+]
+```
+
+O pacote implementa `Bifrost\Framework\Contracts\LogWriter` e deve ser
+instalado somente quando a aplicacao precisar gravar logs em arquivo.

--- a/packages/log-file/composer.json
+++ b/packages/log-file/composer.json
@@ -1,0 +1,26 @@
+{
+  "name": "bifrost/log-file",
+  "description": "Logger opcional em arquivo para o Bifrost Framework",
+  "type": "library",
+  "license": "MIT",
+  "require": {
+    "php": ">=8.1",
+    "bifrost/framework": "^1.0"
+  },
+  "autoload": {
+    "psr-4": {
+      "Bifrost\\Extension\\LogFile\\": "src/"
+    }
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^10.5 || ^11.0 || ^12.0"
+  },
+  "scripts": {
+    "test": "phpunit -c phpunit.xml"
+  },
+  "extra": {
+    "branch-alias": {
+      "dev-main": "1.0-dev"
+    }
+  }
+}

--- a/packages/log-file/phpunit.xml
+++ b/packages/log-file/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php" colors="true">
+    <testsuites>
+        <testsuite name="log-file">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/packages/log-file/src/Contracts/LogWriter.php
+++ b/packages/log-file/src/Contracts/LogWriter.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Bifrost\Extension\LogMongoDb\Contracts;
+namespace Bifrost\Extension\LogFile\Contracts;
 
 use Bifrost\Framework\Contracts\LogWriter as FrameworkLogWriter;
 

--- a/packages/log-file/src/FileLogConfig.php
+++ b/packages/log-file/src/FileLogConfig.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bifrost\Extension\LogFile;
+
+use InvalidArgumentException;
+
+final class FileLogConfig
+{
+    private function __construct(private readonly string $path)
+    {
+    }
+
+    public static function fromArray(array $config): self
+    {
+        $path = $config['path'] ?? null;
+        if (!is_string($path) || trim($path) === '') {
+            throw new InvalidArgumentException('O caminho do arquivo de log e obrigatorio.');
+        }
+
+        return new self(trim($path));
+    }
+
+    public function path(): string
+    {
+        return $this->path;
+    }
+}

--- a/packages/log-file/src/FileLogExtension.php
+++ b/packages/log-file/src/FileLogExtension.php
@@ -2,25 +2,25 @@
 
 declare(strict_types=1);
 
-namespace Bifrost\Extension\LogMongoDb;
+namespace Bifrost\Extension\LogFile;
 
-use Bifrost\Extension\LogMongoDb\Contracts\LogWriter;
+use Bifrost\Extension\LogFile\Contracts\LogWriter;
 use Bifrost\Framework\Application;
 use Bifrost\Framework\Contracts\Extension;
 use Bifrost\Framework\Contracts\LogWriter as FrameworkLogWriter;
 use Bifrost\Framework\Logging\Logger;
 use Closure;
 
-final class MongoLogExtension implements Extension
+final class FileLogExtension implements Extension
 {
-    private readonly MongoLogConfig $config;
+    private readonly FileLogConfig $config;
 
-    /** @var Closure(MongoLogConfig): LogWriter|null */
+    /** @var Closure(FileLogConfig): LogWriter|null */
     private readonly ?Closure $writerFactory;
 
     public function __construct(array $config, ?callable $writerFactory = null)
     {
-        $this->config = MongoLogConfig::fromArray($config);
+        $this->config = FileLogConfig::fromArray($config);
         $this->writerFactory = $writerFactory === null
             ? null
             : Closure::fromCallable($writerFactory);
@@ -48,6 +48,6 @@ final class MongoLogExtension implements Extension
             return ($this->writerFactory)($this->config);
         }
 
-        return MongoLogWriter::connect($this->config);
+        return new FileLogWriter($this->config);
     }
 }

--- a/packages/log-file/src/FileLogWriter.php
+++ b/packages/log-file/src/FileLogWriter.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bifrost\Extension\LogFile;
+
+use Bifrost\Extension\LogFile\Contracts\LogWriter;
+use JsonException;
+use RuntimeException;
+
+final class FileLogWriter implements LogWriter
+{
+    public function __construct(private readonly FileLogConfig $config)
+    {
+    }
+
+    /**
+     * @throws JsonException
+     */
+    public function write(array $entry): void
+    {
+        $directory = dirname($this->config->path());
+        if (!is_dir($directory) && !mkdir($directory, 0775, true) && !is_dir($directory)) {
+            throw new RuntimeException('Nao foi possivel criar o diretorio de logs.');
+        }
+
+        $encoded = json_encode($entry, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        file_put_contents($this->config->path(), $encoded . PHP_EOL, FILE_APPEND | LOCK_EX);
+    }
+}

--- a/packages/log-file/tests/FileLogTest.php
+++ b/packages/log-file/tests/FileLogTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+use Bifrost\Extension\LogFile\Contracts\LogWriter;
+use Bifrost\Extension\LogFile\FileLogConfig;
+use Bifrost\Extension\LogFile\FileLogExtension;
+use Bifrost\Extension\LogFile\FileLogWriter;
+use Bifrost\Framework\Application;
+use Bifrost\Framework\Contracts\LogWriter as FrameworkLogWriter;
+use Bifrost\Framework\Logging\Logger;
+use PHPUnit\Framework\TestCase;
+
+final class FileLogTest extends TestCase
+{
+    public function testWritesJsonLineToConfiguredFile(): void
+    {
+        $path = sys_get_temp_dir() . '/bifrost-file-log-test-' . bin2hex(random_bytes(4)) . '/app.log';
+        $writer = new FileLogWriter(FileLogConfig::fromArray(['path' => $path]));
+
+        $writer->write(['message' => 'teste', 'level' => 'info']);
+
+        self::assertFileExists($path);
+        self::assertJsonStringEqualsJsonString(
+            '{"message":"teste","level":"info"}',
+            trim((string) file_get_contents($path))
+        );
+    }
+
+    public function testExtensionRegistersLocalAndFrameworkContracts(): void
+    {
+        $fakeWriter = new class implements LogWriter {
+            public function write(array $entry): void
+            {
+            }
+        };
+        $application = Application::create()->extend(new FileLogExtension(
+            ['path' => sys_get_temp_dir() . '/bifrost-file.log'],
+            static fn (FileLogConfig $config): LogWriter => $fakeWriter
+        ));
+
+        self::assertSame($fakeWriter, $application->container()->get(LogWriter::class));
+        self::assertSame($fakeWriter, $application->container()->get(FrameworkLogWriter::class));
+        self::assertInstanceOf(Logger::class, $application->container()->get(Logger::class));
+    }
+
+    public function testReusesSameWriterInstanceForLocalAndFrameworkContracts(): void
+    {
+        $fakeWriter = new class implements LogWriter {
+            public function write(array $entry): void
+            {
+            }
+        };
+        $application = Application::create()->extend(new FileLogExtension(
+            ['path' => sys_get_temp_dir() . '/bifrost-file.log'],
+            static fn (FileLogConfig $config): LogWriter => $fakeWriter
+        ));
+
+        self::assertSame(
+            $application->container()->get(LogWriter::class),
+            $application->container()->get(FrameworkLogWriter::class)
+        );
+    }
+}

--- a/packages/log-file/tests/bootstrap.php
+++ b/packages/log-file/tests/bootstrap.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+require dirname(__DIR__) . '/vendor/autoload.php';

--- a/packages/log-mongodb/README.md
+++ b/packages/log-mongodb/README.md
@@ -1,13 +1,13 @@
 # bifrost/log-mongodb
 
-Adapter opcional de persistencia de logs em MongoDB para o Bifrost Framework.
-O pacote registra o contrato local
-`Bifrost\Extension\LogMongoDb\Contracts\LogWriter`, que recebe documentos de
-log prontos e os grava na colecao configurada.
+Pacote opcional de logs em MongoDB para o Bifrost Framework.
+Ele registra `Bifrost\Framework\Logging\Logger` pronto para uso e o contrato local
+`Bifrost\Extension\LogMongoDb\Contracts\LogWriter`, que recebe documentos de log
+prontos e os grava na colecao configurada.
 
 ```php
-use Bifrost\Extension\LogMongoDb\Contracts\LogWriter;
 use Bifrost\Extension\LogMongoDb\MongoLogExtension;
+use Bifrost\Framework\Logging\Logger;
 
 $application->extend(new MongoLogExtension([
     'uri' => 'mongodb://mongo:27017',
@@ -15,31 +15,37 @@ $application->extend(new MongoLogExtension([
     'collection' => 'application_logs',
 ]));
 
-$application->container()->get(LogWriter::class)->write([
-    'timestamp' => gmdate('c'),
-    'level' => 'info',
-    'message' => 'Requisicao recebida',
-    'request_id' => $requestId,
-    'context' => [],
-]);
+$application->container()
+    ->get(Logger::class)
+    ->info('Requisicao recebida', ['route' => '/health']);
 ```
 
 Tambem podem ser informados `host`, `port`, `username` e `password` no lugar
 de `uri`. A porta padrao e `27017` e a colecao padrao e `logs`.
+
+O documento gravado segue o formato legado:
+
+```php
+[
+    'timestamp' => gmdate('c'),
+    'level' => 'info',
+    'message' => 'Requisicao recebida',
+    'request_id' => '...',
+    'context' => [],
+]
+```
 
 ## Compatibilidade
 
 | API existente | Comportamento preservado no pacote |
 | --- | --- |
 | `Bifrost\Integration\Database\MongoDatabase` | Configuracao aceita `uri` ou `host`, `port`, `username`, `password` e `database`; a escrita continua sendo um documento em uma colecao MongoDB. |
-| `Bifrost\Core\Logger` | O documento com `timestamp`, `level`, `message`, `request_id` e `context` pode ser gravado sem transformacao por `LogWriter::write()`. |
+| `Bifrost\Core\Logger` | `Bifrost\Framework\Logging\Logger` gera documento com `timestamp`, `level`, `message`, `request_id` e `context`. |
 | `Bifrost\Interface\NoSqlDatabase` | Permanece contrato do runtime legado; este pacote nao o substitui nem exige alteracao nele. |
 
 Os valores produzidos por `Settings::getSettingsMongo()` podem ser passados
 diretamente a `MongoLogConfig::fromArray()`. O valor legado de
 `BFR_API_LOG_COLLECTION` corresponde a opcao `collection` da extensao.
 
-O framework modular ainda nao publica um contrato comum de logging ou de
-log sink. Por isso, `LogWriter` pertence somente a este pacote e o registro da
-extensao e aditivo; integrar diferentes providers sob o mesmo contrato exige
-primeiro definir esse contrato no framework.
+O framework modular nao possui logger central no core. Este pacote e opcional:
+instale e registre somente quando a aplicacao precisar gravar logs em MongoDB.

--- a/packages/log-mongodb/tests/FrameworkLogWriterContractTest.php
+++ b/packages/log-mongodb/tests/FrameworkLogWriterContractTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+use Bifrost\Extension\LogMongoDb\Contracts\LogWriter;
+use Bifrost\Extension\LogMongoDb\MongoLogConfig;
+use Bifrost\Extension\LogMongoDb\MongoLogExtension;
+use Bifrost\Framework\Application;
+use Bifrost\Framework\Contracts\LogWriter as FrameworkLogWriter;
+use PHPUnit\Framework\TestCase;
+
+final class FrameworkLogWriterContractTest extends TestCase
+{
+    public function testRegistersFrameworkLogWriterContract(): void
+    {
+        $fakeWriter = new class implements LogWriter {
+            public array $entries = [];
+
+            public function write(array $entry): void
+            {
+                $this->entries[] = $entry;
+            }
+        };
+        $application = Application::create()->extend(new MongoLogExtension(
+            [
+                'uri' => 'mongodb://mongo:27017',
+                'database' => 'bifrost_logs',
+            ],
+            static fn (MongoLogConfig $config): LogWriter => $fakeWriter
+        ));
+
+        $writer = $application->container()->get(FrameworkLogWriter::class);
+        $writer->write(['message' => 'teste']);
+
+        self::assertSame($fakeWriter, $writer);
+        self::assertSame([['message' => 'teste']], $fakeWriter->entries);
+    }
+
+    public function testReusesSameWriterInstanceForLocalAndFrameworkContracts(): void
+    {
+        $fakeWriter = new class implements LogWriter {
+            public function write(array $entry): void
+            {
+            }
+        };
+        $application = Application::create()->extend(new MongoLogExtension(
+            [
+                'uri' => 'mongodb://mongo:27017',
+                'database' => 'bifrost_logs',
+            ],
+            static fn (MongoLogConfig $config): LogWriter => $fakeWriter
+        ));
+
+        self::assertSame(
+            $application->container()->get(LogWriter::class),
+            $application->container()->get(FrameworkLogWriter::class)
+        );
+    }
+}

--- a/packages/log-mongodb/tests/MongoLoggerTest.php
+++ b/packages/log-mongodb/tests/MongoLoggerTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use Bifrost\Extension\LogMongoDb\Contracts\LogWriter;
+use Bifrost\Extension\LogMongoDb\MongoLogConfig;
+use Bifrost\Extension\LogMongoDb\MongoLogExtension;
+use Bifrost\Framework\Application;
+use Bifrost\Framework\Logging\Logger;
+use PHPUnit\Framework\TestCase;
+
+final class MongoLoggerTest extends TestCase
+{
+    public function testExtensionRegistersFrameworkLogger(): void
+    {
+        $fakeWriter = new class implements LogWriter {
+            public array $entries = [];
+
+            public function write(array $entry): void
+            {
+                $this->entries[] = $entry;
+            }
+        };
+        $application = Application::create()->extend(new MongoLogExtension(
+            [
+                'uri' => 'mongodb://mongo:27017',
+                'database' => 'bifrost_logs',
+            ],
+            static fn (MongoLogConfig $config): LogWriter => $fakeWriter
+        ));
+
+        $logger = $application->container()->get(Logger::class);
+
+        self::assertInstanceOf(Logger::class, $logger);
+    }
+}

--- a/packages/log-stdout/README.md
+++ b/packages/log-stdout/README.md
@@ -1,0 +1,20 @@
+# bifrost/log-stdout
+
+Pacote opcional de logs em `stdout` ou `stderr` para o Bifrost Framework.
+E indicado para Docker, Kubernetes e plataformas que coletam logs do processo.
+
+```php
+use Bifrost\Extension\LogStdout\StdoutLogExtension;
+use Bifrost\Framework\Logging\Logger;
+
+$application->extend(new StdoutLogExtension([
+    'stream' => 'stdout',
+]));
+
+$application->container()
+    ->get(Logger::class)
+    ->info('Requisicao recebida', ['route' => '/health']);
+```
+
+Cada entrada e gravada como uma linha JSON com `timestamp`, `level`,
+`message`, `request_id` e `context`.

--- a/packages/log-stdout/composer.json
+++ b/packages/log-stdout/composer.json
@@ -1,0 +1,26 @@
+{
+  "name": "bifrost/log-stdout",
+  "description": "Logger opcional stdout/stderr para o Bifrost Framework",
+  "type": "library",
+  "license": "MIT",
+  "require": {
+    "php": ">=8.1",
+    "bifrost/framework": "^1.0"
+  },
+  "autoload": {
+    "psr-4": {
+      "Bifrost\\Extension\\LogStdout\\": "src/"
+    }
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^10.5 || ^11.0 || ^12.0"
+  },
+  "scripts": {
+    "test": "phpunit -c phpunit.xml"
+  },
+  "extra": {
+    "branch-alias": {
+      "dev-main": "1.0-dev"
+    }
+  }
+}

--- a/packages/log-stdout/phpunit.xml
+++ b/packages/log-stdout/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php" colors="true">
+    <testsuites>
+        <testsuite name="log-stdout">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/packages/log-stdout/src/Contracts/LogWriter.php
+++ b/packages/log-stdout/src/Contracts/LogWriter.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Bifrost\Extension\LogMongoDb\Contracts;
+namespace Bifrost\Extension\LogStdout\Contracts;
 
 use Bifrost\Framework\Contracts\LogWriter as FrameworkLogWriter;
 

--- a/packages/log-stdout/src/StdoutLogConfig.php
+++ b/packages/log-stdout/src/StdoutLogConfig.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bifrost\Extension\LogStdout;
+
+use InvalidArgumentException;
+
+final class StdoutLogConfig
+{
+    private function __construct(private readonly string $stream)
+    {
+    }
+
+    public static function fromArray(array $config = []): self
+    {
+        $stream = $config['stream'] ?? 'stdout';
+        if (!is_string($stream) || !in_array($stream, ['stdout', 'stderr'], true)) {
+            throw new InvalidArgumentException('O stream de log deve ser stdout ou stderr.');
+        }
+
+        return new self($stream);
+    }
+
+    public function stream(): string
+    {
+        return $this->stream;
+    }
+}

--- a/packages/log-stdout/src/StdoutLogExtension.php
+++ b/packages/log-stdout/src/StdoutLogExtension.php
@@ -2,25 +2,25 @@
 
 declare(strict_types=1);
 
-namespace Bifrost\Extension\LogMongoDb;
+namespace Bifrost\Extension\LogStdout;
 
-use Bifrost\Extension\LogMongoDb\Contracts\LogWriter;
+use Bifrost\Extension\LogStdout\Contracts\LogWriter;
 use Bifrost\Framework\Application;
 use Bifrost\Framework\Contracts\Extension;
 use Bifrost\Framework\Contracts\LogWriter as FrameworkLogWriter;
 use Bifrost\Framework\Logging\Logger;
 use Closure;
 
-final class MongoLogExtension implements Extension
+final class StdoutLogExtension implements Extension
 {
-    private readonly MongoLogConfig $config;
+    private readonly StdoutLogConfig $config;
 
-    /** @var Closure(MongoLogConfig): LogWriter|null */
+    /** @var Closure(StdoutLogConfig): LogWriter|null */
     private readonly ?Closure $writerFactory;
 
-    public function __construct(array $config, ?callable $writerFactory = null)
+    public function __construct(array $config = [], ?callable $writerFactory = null)
     {
-        $this->config = MongoLogConfig::fromArray($config);
+        $this->config = StdoutLogConfig::fromArray($config);
         $this->writerFactory = $writerFactory === null
             ? null
             : Closure::fromCallable($writerFactory);
@@ -48,6 +48,6 @@ final class MongoLogExtension implements Extension
             return ($this->writerFactory)($this->config);
         }
 
-        return MongoLogWriter::connect($this->config);
+        return new StdoutLogWriter($this->config);
     }
 }

--- a/packages/log-stdout/src/StdoutLogWriter.php
+++ b/packages/log-stdout/src/StdoutLogWriter.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bifrost\Extension\LogStdout;
+
+use Bifrost\Extension\LogStdout\Contracts\LogWriter;
+use Closure;
+use JsonException;
+
+final class StdoutLogWriter implements LogWriter
+{
+    /** @var Closure(string): void */
+    private readonly Closure $writeLine;
+
+    public function __construct(StdoutLogConfig $config, ?callable $writeLine = null)
+    {
+        $this->writeLine = Closure::fromCallable(
+            $writeLine ?? static function (string $line) use ($config): void {
+                $target = $config->stream() === 'stderr' ? 'php://stderr' : 'php://stdout';
+                file_put_contents($target, $line . PHP_EOL);
+            }
+        );
+    }
+
+    /**
+     * @throws JsonException
+     */
+    public function write(array $entry): void
+    {
+        ($this->writeLine)(json_encode($entry, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+    }
+}

--- a/packages/log-stdout/tests/StdoutLogTest.php
+++ b/packages/log-stdout/tests/StdoutLogTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+use Bifrost\Extension\LogStdout\Contracts\LogWriter;
+use Bifrost\Extension\LogStdout\StdoutLogConfig;
+use Bifrost\Extension\LogStdout\StdoutLogExtension;
+use Bifrost\Extension\LogStdout\StdoutLogWriter;
+use Bifrost\Framework\Application;
+use Bifrost\Framework\Contracts\LogWriter as FrameworkLogWriter;
+use Bifrost\Framework\Logging\Logger;
+use PHPUnit\Framework\TestCase;
+
+final class StdoutLogTest extends TestCase
+{
+    public function testWritesJsonLineToConfiguredCallback(): void
+    {
+        $lines = [];
+        $writer = new StdoutLogWriter(
+            StdoutLogConfig::fromArray(['stream' => 'stderr']),
+            static function (string $line) use (&$lines): void {
+                $lines[] = $line;
+            }
+        );
+
+        $writer->write(['message' => 'teste', 'level' => 'info']);
+
+        self::assertCount(1, $lines);
+        self::assertJsonStringEqualsJsonString('{"message":"teste","level":"info"}', $lines[0]);
+    }
+
+    public function testExtensionRegistersLocalAndFrameworkContracts(): void
+    {
+        $fakeWriter = new class implements LogWriter {
+            public function write(array $entry): void
+            {
+            }
+        };
+        $application = Application::create()->extend(new StdoutLogExtension(
+            ['stream' => 'stdout'],
+            static fn (StdoutLogConfig $config): LogWriter => $fakeWriter
+        ));
+
+        self::assertSame($fakeWriter, $application->container()->get(LogWriter::class));
+        self::assertSame($fakeWriter, $application->container()->get(FrameworkLogWriter::class));
+        self::assertInstanceOf(Logger::class, $application->container()->get(Logger::class));
+    }
+
+    public function testReusesSameWriterInstanceForLocalAndFrameworkContracts(): void
+    {
+        $fakeWriter = new class implements LogWriter {
+            public function write(array $entry): void
+            {
+            }
+        };
+        $application = Application::create()->extend(new StdoutLogExtension(
+            ['stream' => 'stdout'],
+            static fn (StdoutLogConfig $config): LogWriter => $fakeWriter
+        ));
+
+        self::assertSame(
+            $application->container()->get(LogWriter::class),
+            $application->container()->get(FrameworkLogWriter::class)
+        );
+    }
+}

--- a/packages/log-stdout/tests/bootstrap.php
+++ b/packages/log-stdout/tests/bootstrap.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+require dirname(__DIR__) . '/vendor/autoload.php';

--- a/skeleton/.env.example
+++ b/skeleton/.env.example
@@ -20,3 +20,17 @@ APP_PORT=8080
 # DB_DATABASE=app
 # DB_USERNAME=app
 # DB_PASSWORD=app
+
+# Preencha ao instalar um unico pacote de log:
+# LOG_DRIVER=stdout
+# LOG_DRIVER=file
+# LOG_DRIVER=mongodb
+# LOG_STREAM=stdout
+# LOG_FILE=storage/logs/app.log
+# MONGO_LOG_URI=mongodb://mongo:27017
+# MONGO_LOG_HOST=mongo
+# MONGO_LOG_PORT=27017
+# MONGO_LOG_DATABASE=bifrost_logs
+# MONGO_LOG_COLLECTION=logs
+# MONGO_LOG_USERNAME=
+# MONGO_LOG_PASSWORD=

--- a/skeleton/app/Http/Controller/HealthController.php
+++ b/skeleton/app/Http/Controller/HealthController.php
@@ -7,8 +7,14 @@ namespace App\Http\Controller;
 use Bifrost\Framework\Http\Request;
 use Bifrost\Framework\Http\Response;
 
+/**
+ * Controller de health check do projeto base.
+ */
 final class HealthController
 {
+    /**
+     * Retorna status basico da aplicacao.
+     */
     public static function show(Request $request): Response
     {
         return Response::json(payload: ['status' => 'ok']);

--- a/skeleton/config/extensions.php
+++ b/skeleton/config/extensions.php
@@ -6,6 +6,9 @@ use Bifrost\Extension\CacheApcu\ApcuCacheExtension;
 use Bifrost\Extension\CacheRedis\RedisCacheExtension;
 use Bifrost\Extension\DatabaseMySql\MySqlExtension;
 use Bifrost\Extension\DatabasePostgreSql\PostgreSqlExtension;
+use Bifrost\Extension\LogFile\FileLogExtension;
+use Bifrost\Extension\LogMongoDb\MongoLogExtension;
+use Bifrost\Extension\LogStdout\StdoutLogExtension;
 use Bifrost\Extension\QueueRedis\RedisQueueExtension;
 use Bifrost\Framework\Contracts\Extension;
 
@@ -80,6 +83,47 @@ if ($databaseDriver === 'postgresql' && !class_exists(PostgreSqlExtension::class
 
 if ($databaseDriver === 'postgresql') {
     $extensions[] = new PostgreSqlExtension($databaseConfig);
+}
+
+$logDriver = getenv('LOG_DRIVER') ?: '';
+if ($logDriver !== '' && !in_array($logDriver, ['stdout', 'file', 'mongodb'], true)) {
+    throw new RuntimeException('LOG_DRIVER deve ser stdout, file ou mongodb.');
+}
+
+if ($logDriver === 'stdout' && !class_exists(StdoutLogExtension::class)) {
+    throw new RuntimeException('Instale bifrost/log-stdout para usar LOG_DRIVER=stdout.');
+}
+
+if ($logDriver === 'stdout') {
+    $extensions[] = new StdoutLogExtension([
+        'stream' => getenv('LOG_STREAM') ?: 'stdout',
+    ]);
+}
+
+if ($logDriver === 'file' && !class_exists(FileLogExtension::class)) {
+    throw new RuntimeException('Instale bifrost/log-file para usar LOG_DRIVER=file.');
+}
+
+if ($logDriver === 'file') {
+    $extensions[] = new FileLogExtension([
+        'path' => getenv('LOG_FILE') ?: dirname(__DIR__) . '/storage/logs/app.log',
+    ]);
+}
+
+if ($logDriver === 'mongodb' && !class_exists(MongoLogExtension::class)) {
+    throw new RuntimeException('Instale bifrost/log-mongodb para usar LOG_DRIVER=mongodb.');
+}
+
+if ($logDriver === 'mongodb') {
+    $extensions[] = new MongoLogExtension([
+        'uri' => getenv('MONGO_LOG_URI') ?: null,
+        'host' => getenv('MONGO_LOG_HOST') ?: 'mongo',
+        'port' => getenv('MONGO_LOG_PORT') ?: '27017',
+        'database' => getenv('MONGO_LOG_DATABASE') ?: 'bifrost_logs',
+        'collection' => getenv('MONGO_LOG_COLLECTION') ?: 'logs',
+        'username' => getenv('MONGO_LOG_USERNAME') ?: null,
+        'password' => getenv('MONGO_LOG_PASSWORD') ?: null,
+    ]);
 }
 
 return $extensions;

--- a/skeleton/tests/LogExtensionConfigurationTest.php
+++ b/skeleton/tests/LogExtensionConfigurationTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class LogExtensionConfigurationTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        putenv('LOG_DRIVER');
+        putenv('MONGO_LOG_URI');
+        putenv('MONGO_LOG_HOST');
+        putenv('MONGO_LOG_PORT');
+        putenv('MONGO_LOG_DATABASE');
+        putenv('MONGO_LOG_COLLECTION');
+        putenv('MONGO_LOG_USERNAME');
+        putenv('MONGO_LOG_PASSWORD');
+    }
+
+    public function testRejectsUnsupportedLogDriver(): void
+    {
+        putenv('LOG_DRIVER=syslog');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('LOG_DRIVER deve ser stdout, file ou mongodb.');
+
+        require dirname(__DIR__) . '/config/extensions.php';
+    }
+
+    public function testRequiresInstalledPackageForConfiguredStdoutLog(): void
+    {
+        putenv('LOG_DRIVER=stdout');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Instale bifrost/log-stdout');
+
+        require dirname(__DIR__) . '/config/extensions.php';
+    }
+
+    public function testRequiresInstalledPackageForConfiguredFileLog(): void
+    {
+        putenv('LOG_DRIVER=file');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Instale bifrost/log-file');
+
+        require dirname(__DIR__) . '/config/extensions.php';
+    }
+
+    public function testRequiresInstalledPackageForConfiguredMongoLog(): void
+    {
+        putenv('LOG_DRIVER=mongodb');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Instale bifrost/log-mongodb');
+
+        require dirname(__DIR__) . '/config/extensions.php';
+    }
+}


### PR DESCRIPTION
## Objetivo
Adicionar hooks do lifecycle HTTP e observabilidade desacoplada.

## Principais mudanças
- adiciona hooks before/after e transaction manager;
- adiciona attributes de cache e transação;
- adiciona logger comum e writers opcionais para stdout, arquivo e MongoDB;
- integra configuração opcional ao skeleton.

## Testes executados
- testes focados foram executados durante a implementação original;
- suíte modular completa pendente por timeout recente.

## Ordem de merge
PR 4. Depende do PR anterior.