### PR TITLE
refactor: encapsula conexões Redis e clientes S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ com core pequeno, extensoes opcionais e um skeleton de projeto.
 | --- | --- |
 | `bifrost/framework` | Kernel HTTP, request/response, rotas, middleware, container e contratos |
 | `bifrost/cache-apcu` | Cache APCu opcional |
+| `bifrost/redis` | Conexao Redis reutilizavel para extensoes opcionais |
 | `bifrost/cache-redis` | Cache Redis opcional |
 | `bifrost/queue-redis` | Fila Redis opcional |
 | `bifrost/database-pdo` | Fabrica PDO generica opcional |
@@ -95,6 +96,7 @@ pacote escolhido (`apcu`, `redis`, `pdo_mysql` ou `pdo_pgsql`).
 |-- packages/
 |   |-- framework/
 |   |-- cache-apcu/
+|   |-- redis/
 |   |-- cache-redis/
 |   |-- queue-redis/
 |   |-- database-pdo/

--- a/docker/modular/check.sh
+++ b/docker/modular/check.sh
@@ -6,12 +6,15 @@ composer validate --strict --no-check-publish packages/framework/composer.json
 composer install --working-dir=packages/framework --no-interaction --no-progress --prefer-dist
 composer check --working-dir=packages/framework
 
-for package in datatypes cache-redis cache-apcu queue-redis queue-worker database-pdo log-mongodb storage-local storage-s3; do
+for package in datatypes redis cache-redis cache-apcu queue-redis queue-worker database-pdo log-stdout log-file log-mongodb storage-local storage-s3; do
     (
         cd "packages/$package"
         composer validate --strict --no-check-publish composer.json
         composer config minimum-stability dev
         composer config repositories.framework path ../framework
+        if [ "$package" = "cache-redis" ] || [ "$package" = "queue-redis" ]; then
+            composer config repositories.redis path ../redis
+        fi
         composer update --no-interaction --no-progress --prefer-dist
         composer test
     )

--- a/docs/human/01-criando-projeto.html
+++ b/docs/human/01-criando-projeto.html
@@ -8,25 +8,41 @@
 </head>
 <body>
   <main>
-    <a href="index.html">← voltar</a>
-    <section class="section panel">
-      <h1>Criar um projeto novo</h1>
-      <p>O sistema pode ter frontend, banco, app mobile e outros modulos. O backend PHP fica dentro da pasta <code>api/</code>.</p>
-      <div class="grid">
-        <div class="card"><h2>1. Pasta</h2><p>Crie <code>api/</code> na raiz do sistema.</p></div>
-        <div class="card"><h2>2. Skeleton</h2><p>Instale <code>bifrost/skeleton</code> dentro dela.</p></div>
-        <div class="card"><h2>3. Rodar</h2><p>Suba Docker e acesse <code>/health</code>.</p></div>
+    <header class="topbar">
+      <a class="brand" href="index.html"><span class="brand-mark"></span>Bifrost</a>
+      <nav class="nav">
+        <a href="01-criando-projeto.html">Inicio</a>
+        <a href="02-arquitetura.html">Arquitetura</a>
+        <a href="03-lifecycle.html">Lifecycle</a>
+        <a href="04-modulos.html">Modulos</a>
+        <a href="05-attributes-datatypes.html">Attributes</a>
+        <a href="06-deploy.html">Deploy</a>
+      </nav>
+    </header>
+
+    <section class="hero">
+      <div>
+        <span class="eyebrow">Comece pelo skeleton</span>
+        <h1>Criar um backend do zero.</h1>
+        <p class="lead">A aplicacao PHP fica em <code>api/</code>. O skeleton instala apenas o core, com rotas, controller de health check e Docker prontos.</p>
       </div>
-    </section>
-    <section class="section panel terminal">
-      <div class="bar"><span class="dot red"></span><span class="dot yellow"></span><span class="dot green"></span></div>
-      <pre>mkdir api
+      <div class="panel terminal">
+        <div class="bar"><span class="dot red"></span><span class="dot yellow"></span><span class="dot green"></span></div>
+        <pre>mkdir api
 cd api
 composer create-project bifrost/skeleton .
 cp .env.example .env
 docker compose up --build
 curl http://localhost:8080/health</pre>
+      </div>
+    </section>
+
+    <section class="grid">
+      <div class="card"><h2>1. Pasta</h2><p>Crie <code>api/</code> dentro do sistema consumidor.</p></div>
+      <div class="card"><h2>2. Skeleton</h2><p>Instale <code>bifrost/skeleton</code> dentro de <code>api/</code>.</p></div>
+      <div class="card"><h2>3. Extensoes</h2><p>Adicione pacotes opcionais apenas quando precisar.</p></div>
     </section>
   </main>
+  <script src="assets/app.js"></script>
 </body>
 </html>

--- a/docs/human/02-arquitetura.html
+++ b/docs/human/02-arquitetura.html
@@ -8,33 +8,29 @@
 </head>
 <body>
   <main>
-    <a href="index.html">← voltar</a>
+    <header class="topbar">
+      <a class="brand" href="index.html"><span class="brand-mark"></span>Bifrost</a>
+      <nav class="nav">
+        <a href="01-criando-projeto.html">Inicio</a>
+        <a href="02-arquitetura.html">Arquitetura</a>
+        <a href="03-lifecycle.html">Lifecycle</a>
+        <a href="04-modulos.html">Modulos</a>
+        <a href="05-attributes-datatypes.html">Attributes</a>
+        <a href="06-deploy.html">Deploy</a>
+      </nav>
+    </header>
+
     <section class="section panel">
-      <h1>Arquitetura</h1>
-      <p>O framework e pequeno. Funcionalidades opcionais entram por Composer.</p>
-      <svg width="100%" height="320" viewBox="0 0 920 320" role="img">
-        <rect x="40" y="115" width="140" height="90" rx="20" fill="#10243d" stroke="#274966"/>
-        <text x="72" y="154">Projeto</text><text x="70" y="178">meu-sistema</text>
-        <rect x="245" y="40" width="145" height="80" rx="20" fill="#10243d" stroke="#274966"/>
-        <text x="286" y="77">api/</text><text x="278" y="99">backend</text>
-        <rect x="245" y="200" width="145" height="80" rx="20" fill="#10243d" stroke="#274966"/>
-        <text x="283" y="237">app/</text><text x="267" y="259">frontend</text>
-        <rect x="470" y="40" width="160" height="80" rx="20" fill="#10243d" stroke="#274966"/>
-        <text x="506" y="77">framework</text>
-        <rect x="470" y="140" width="160" height="80" rx="20" fill="#10243d" stroke="#274966"/>
-        <text x="510" y="177">datatypes</text>
-        <rect x="470" y="240" width="160" height="60" rx="20" fill="#10243d" stroke="#274966"/>
-        <text x="510" y="275">extensions</text>
-        <rect x="720" y="115" width="150" height="90" rx="20" fill="#10243d" stroke="#274966"/>
-        <text x="761" y="154">Composer</text><text x="755" y="178">instala so uso</text>
-        <path d="M180 160 H245" stroke="#63e6be" stroke-width="4" stroke-linecap="round"/>
-        <path d="M390 80 H470" stroke="#63e6be" stroke-width="4" stroke-linecap="round"/>
-        <path d="M390 80 C430 80 430 180 470 180" stroke="#6ea8fe" stroke-width="4" fill="none"/>
-        <path d="M390 80 C430 80 430 270 470 270" stroke="#6ea8fe" stroke-width="4" fill="none"/>
-        <path d="M630 180 H720" stroke="#63e6be" stroke-width="4" stroke-linecap="round"/>
-        <circle class="pulse" cx="430" cy="80" r="9" fill="#63e6be"/>
-      </svg>
+      <span class="eyebrow">Core pequeno</span>
+      <h1>Arquitetura modular</h1>
+      <p class="lead">O Bifrost separa o que e HTTP do que e infraestrutura. O framework define contratos; extensoes opcionais implementam fornecedores.</p>
+      <div class="grid">
+        <div class="card"><h2>Core</h2><p><code>Application</code>, <code>Container</code>, <code>HttpKernel</code>, rotas, request, response e attributes.</p></div>
+        <div class="card"><h2>Skeleton</h2><p>Projeto inicial com <code>bootstrap/app.php</code>, <code>routes/api.php</code> e Docker.</p></div>
+        <div class="card"><h2>Extensoes</h2><p>Pacotes Composer registram cache, banco, fila, storage e logs no container.</p></div>
+      </div>
     </section>
   </main>
+  <script src="assets/app.js"></script>
 </body>
 </html>

--- a/docs/human/03-lifecycle.html
+++ b/docs/human/03-lifecycle.html
@@ -8,19 +8,35 @@
 </head>
 <body>
   <main>
-    <a href="index.html">← voltar</a>
+    <header class="topbar">
+      <a class="brand" href="index.html"><span class="brand-mark"></span>Bifrost</a>
+      <nav class="nav">
+        <a href="01-criando-projeto.html">Inicio</a>
+        <a href="02-arquitetura.html">Arquitetura</a>
+        <a href="03-lifecycle.html">Lifecycle</a>
+        <a href="04-modulos.html">Modulos</a>
+        <a href="05-attributes-datatypes.html">Attributes</a>
+        <a href="06-deploy.html">Deploy</a>
+      </nav>
+    </header>
+
     <section class="section panel">
+      <span class="eyebrow">Request para response</span>
       <h1>Lifecycle HTTP</h1>
-      <p>Da entrada da request ate a resposta final.</p>
-      <div class="flow">
-        <div class="step" style="--i:0"><b>public/index.php</b><span>Entrypoint unico.</span></div>
-        <div class="step" style="--i:1"><b>bootstrap/app.php</b><span>Monta a aplicacao.</span></div>
-        <div class="step" style="--i:2"><b>extensions</b><span>Registra pacotes.</span></div>
-        <div class="step" style="--i:3"><b>attributes</b><span>Valida metodo e dados.</span></div>
-        <div class="step" style="--i:4"><b>controller</b><span>Executa regra do app.</span></div>
-        <div class="step" style="--i:5"><b>response</b><span>Emite HTTP.</span></div>
+      <p class="lead">A request entra pelo front controller, passa pelo kernel, middlewares, rota e controller, e sempre volta como <code>Response</code>.</p>
+      <div class="panel terminal">
+        <div class="bar"><span class="dot red"></span><span class="dot yellow"></span><span class="dot green"></span></div>
+        <pre>public/index.php
+  -> Request::fromGlobals()
+  -> Application
+  -> HttpKernel
+  -> middleware
+  -> Router
+  -> ControllerResolver
+  -> ResponseEmitter</pre>
       </div>
     </section>
   </main>
+  <script src="assets/app.js"></script>
 </body>
 </html>

--- a/docs/human/04-modulos.html
+++ b/docs/human/04-modulos.html
@@ -8,19 +8,34 @@
 </head>
 <body>
   <main>
-    <a href="index.html">← voltar</a>
+    <header class="topbar">
+      <a class="brand" href="index.html"><span class="brand-mark"></span>Bifrost</a>
+      <nav class="nav">
+        <a href="01-criando-projeto.html">Inicio</a>
+        <a href="02-arquitetura.html">Arquitetura</a>
+        <a href="03-lifecycle.html">Lifecycle</a>
+        <a href="04-modulos.html">Modulos</a>
+        <a href="05-attributes-datatypes.html">Attributes</a>
+        <a href="06-deploy.html">Deploy</a>
+      </nav>
+    </header>
+
     <section class="section panel">
+      <span class="eyebrow">Instale sob demanda</span>
       <h1>Modulos opcionais</h1>
-      <p>Instale somente o que o projeto precisa.</p>
-      <div class="grid">
-        <div class="card"><h2>Core</h2><p><code>bifrost/framework</code></p></div>
-        <div class="card"><h2>DataTypes</h2><p><code>bifrost/datatypes</code></p></div>
-        <div class="card"><h2>Cache</h2><p><code>cache-apcu</code> ou <code>cache-redis</code></p></div>
-        <div class="card"><h2>Fila</h2><p><code>queue-redis</code> ou processamento sync.</p></div>
-        <div class="card"><h2>Banco</h2><p><code>database-mysql</code> ou <code>database-postgresql</code></p></div>
-        <div class="card"><h2>Storage</h2><p><code>storage-local</code> ou <code>storage-s3</code></p></div>
-      </div>
+      <p class="lead">O core nao carrega fornecedores externos. Cada integracao vive em um pacote Composer proprio.</p>
+      <table class="table">
+        <thead><tr><th>Area</th><th>Pacotes</th><th>Observacao</th></tr></thead>
+        <tbody>
+          <tr><td>Cache</td><td><code>bifrost/cache-apcu</code>, <code>bifrost/cache-redis</code></td><td>Redis usa <code>bifrost/redis</code> automaticamente.</td></tr>
+          <tr><td>Fila</td><td><code>bifrost/queue-redis</code>, <code>bifrost/queue-worker</code></td><td>O worker processa <code>TaskPayload</code> por handlers registrados.</td></tr>
+          <tr><td>Banco</td><td><code>bifrost/database-pdo</code>, MySQL, PostgreSQL, SQLite</td><td>Conexoes PDO sao reutilizadas pela factory.</td></tr>
+          <tr><td>Storage</td><td><code>bifrost/storage-local</code>, <code>bifrost/storage-s3</code></td><td>S3 usa <code>S3ClientFactory</code> e manager compartilhado.</td></tr>
+          <tr><td>Logs</td><td><code>bifrost/log-stdout</code>, <code>bifrost/log-file</code>, <code>bifrost/log-mongodb</code></td><td>Todos expõem o mesmo logger estruturado.</td></tr>
+        </tbody>
+      </table>
     </section>
   </main>
+  <script src="assets/app.js"></script>
 </body>
 </html>

--- a/docs/human/05-attributes-datatypes.html
+++ b/docs/human/05-attributes-datatypes.html
@@ -8,25 +8,40 @@
 </head>
 <body>
   <main>
-    <a href="index.html">← voltar</a>
+    <header class="topbar">
+      <a class="brand" href="index.html"><span class="brand-mark"></span>Bifrost</a>
+      <nav class="nav">
+        <a href="01-criando-projeto.html">Inicio</a>
+        <a href="02-arquitetura.html">Arquitetura</a>
+        <a href="03-lifecycle.html">Lifecycle</a>
+        <a href="04-modulos.html">Modulos</a>
+        <a href="05-attributes-datatypes.html">Attributes</a>
+        <a href="06-deploy.html">Deploy</a>
+      </nav>
+    </header>
+
     <section class="section panel">
+      <span class="eyebrow">Contrato no codigo</span>
       <h1>Attributes e DataTypes</h1>
-      <p>Attributes descrevem o contrato HTTP. DataTypes carregam validacao e valor tipado.</p>
+      <p class="lead">Attributes validam o contrato HTTP e podem executar hooks antes/depois da action. DataTypes carregam validacao reutilizavel.</p>
       <div class="grid">
-        <div class="card"><h2>Method</h2><p>Garante o verbo HTTP esperado.</p></div>
-        <div class="card"><h2>RequiredFields</h2><p>Valida corpo obrigatorio.</p></div>
-        <div class="card"><h2>DataTypes</h2><p>Ex.: <code>Email</code>, <code>Cpf</code>, <code>Uuid</code>.</p></div>
+        <div class="card"><h2>Validacao</h2><p><code>RequiredFields</code>, <code>OptionalFields</code>, <code>RequiredParams</code> e <code>OptionalParams</code>.</p></div>
+        <div class="card"><h2>Hooks</h2><p><code>Cache</code> pode reutilizar responses; <code>Transaction</code> controla commit/rollback.</p></div>
+        <div class="card"><h2>Tipos</h2><p><code>Email</code>, <code>Uuid</code>, <code>Cpf</code>, <code>Cnpj</code>, arquivos, URLs e JSON.</p></div>
       </div>
     </section>
+
     <section class="section panel terminal">
       <div class="bar"><span class="dot red"></span><span class="dot yellow"></span><span class="dot green"></span></div>
       <pre>#[Method('POST')]
-#[RequiredFields([
-    'email' => Email::class,
-    'cpf' => Cpf::class,
-])]
-public function store(Request $request): Response</pre>
+#[RequiredFields(['email' => Email::class])]
+#[Transaction]
+public static function store(Request $request): Response
+{
+    return Response::created(['status' => 'ok']);
+}</pre>
     </section>
   </main>
+  <script src="assets/app.js"></script>
 </body>
 </html>

--- a/docs/human/06-deploy.html
+++ b/docs/human/06-deploy.html
@@ -8,19 +8,30 @@
 </head>
 <body>
   <main>
-    <a href="index.html">← voltar</a>
+    <header class="topbar">
+      <a class="brand" href="index.html"><span class="brand-mark"></span>Bifrost</a>
+      <nav class="nav">
+        <a href="01-criando-projeto.html">Inicio</a>
+        <a href="02-arquitetura.html">Arquitetura</a>
+        <a href="03-lifecycle.html">Lifecycle</a>
+        <a href="04-modulos.html">Modulos</a>
+        <a href="05-attributes-datatypes.html">Attributes</a>
+        <a href="06-deploy.html">Deploy</a>
+      </nav>
+    </header>
+
     <section class="section panel">
-      <h1>Docker e Deploy</h1>
-      <p>O skeleton deve iniciar simples e receber overlays quando precisar de infraestrutura.</p>
-      <div class="flow">
-        <div class="step" style="--i:0"><b>base</b><span>PHP + servidor HTTP.</span></div>
-        <div class="step" style="--i:1"><b>redis</b><span>Cache e fila.</span></div>
-        <div class="step" style="--i:2"><b>mysql</b><span>Banco opcional.</span></div>
-        <div class="step" style="--i:3"><b>postgres</b><span>Banco opcional.</span></div>
-        <div class="step" style="--i:4"><b>s3</b><span>Storage externo.</span></div>
-        <div class="step" style="--i:5"><b>logs</b><span>Observabilidade.</span></div>
+      <span class="eyebrow">Ambiente previsivel</span>
+      <h1>Docker e deploy</h1>
+      <p class="lead">O skeleton sobe sem infraestrutura externa. Overlays adicionam Redis, banco ou extensoes PHP conforme os pacotes instalados.</p>
+      <div class="panel terminal">
+        <div class="bar"><span class="dot red"></span><span class="dot yellow"></span><span class="dot green"></span></div>
+        <pre>docker compose up --build
+docker compose -f docker-compose.yml -f compose/redis.yml up --build
+docker compose -f docker-compose.yml -f compose/postgresql.yml up --build</pre>
       </div>
     </section>
   </main>
+  <script src="assets/app.js"></script>
 </body>
 </html>

--- a/docs/human/assets/app.js
+++ b/docs/human/assets/app.js
@@ -1,0 +1,26 @@
+document.querySelectorAll('pre').forEach((pre) => {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'code-wrap';
+  pre.parentNode.insertBefore(wrapper, pre);
+  wrapper.appendChild(pre);
+
+  const button = document.createElement('button');
+  button.className = 'copy-code';
+  button.type = 'button';
+  button.textContent = 'Copiar';
+  button.addEventListener('click', async () => {
+    await navigator.clipboard.writeText(pre.innerText);
+    button.textContent = 'Copiado';
+    setTimeout(() => {
+      button.textContent = 'Copiar';
+    }, 1200);
+  });
+  wrapper.appendChild(button);
+});
+
+const current = location.pathname.split('/').pop() || 'index.html';
+document.querySelectorAll('.nav a').forEach((link) => {
+  if (link.getAttribute('href') === current) {
+    link.setAttribute('aria-current', 'page');
+  }
+});

--- a/docs/human/assets/styles.css
+++ b/docs/human/assets/styles.css
@@ -1,167 +1,277 @@
 :root {
-  --bg: #07111f;
-  --panel: #0d1b2f;
-  --panel-2: #10243d;
-  --text: #e7eefb;
-  --muted: #9fb0cc;
-  --line: #274966;
-  --accent: #63e6be;
-  --blue: #6ea8fe;
-  --yellow: #ffd166;
+  --bg: #fbfaf8;
+  --surface: #ffffff;
+  --surface-muted: #f4f0ea;
+  --text: #241f1c;
+  --muted: #6f6761;
+  --line: #e5ddd3;
+  --accent: #e04f39;
+  --accent-dark: #b83b2b;
+  --code: #1f2937;
+  --code-bg: #121212;
+  --green: #16784a;
 }
 
 * { box-sizing: border-box; }
 
+html { scroll-behavior: smooth; }
+
 body {
   margin: 0;
-  font-family: Inter, Segoe UI, Arial, sans-serif;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   color: var(--text);
-  background:
-    radial-gradient(circle at top left, rgba(99, 230, 190, .16), transparent 32rem),
-    radial-gradient(circle at top right, rgba(110, 168, 254, .14), transparent 30rem),
-    var(--bg);
+  background: var(--bg);
 }
+
+a { color: var(--accent-dark); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+p { color: var(--muted); line-height: 1.7; }
+code { color: var(--accent-dark); font-weight: 650; }
+
+h1 {
+  margin: 0;
+  max-width: 920px;
+  font-size: clamp(40px, 7vw, 86px);
+  line-height: .95;
+  letter-spacing: 0;
+}
+
+h2, h3 { margin: 0 0 10px; line-height: 1.15; }
 
 main {
-  width: min(1120px, calc(100% - 32px));
+  width: min(1180px, calc(100% - 32px));
   margin: 0 auto;
-  padding: 44px 0 72px;
+  padding: 32px 0 72px;
 }
 
-a { color: var(--accent); text-decoration: none; }
-p { color: var(--muted); line-height: 1.65; }
-h1 { margin: 0; font-size: clamp(38px, 6vw, 76px); line-height: .95; letter-spacing: -.06em; }
-h2, h3 { margin-top: 0; }
-code { color: var(--accent); }
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  padding: 16px 0 34px;
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--text);
+  font-weight: 800;
+}
+
+.brand-mark {
+  width: 28px;
+  height: 28px;
+  border-radius: 7px;
+  background: var(--accent);
+  box-shadow: inset 0 -8px 0 rgba(0, 0, 0, .12);
+}
+
+.nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  font-size: 14px;
+}
+
+.nav a {
+  color: var(--muted);
+  padding: 7px 0;
+}
+
+.nav a[aria-current="page"] {
+  color: var(--accent-dark);
+  font-weight: 700;
+}
 
 .hero {
   display: grid;
-  grid-template-columns: 1.05fr .95fr;
-  gap: 28px;
+  grid-template-columns: minmax(0, 1fr) minmax(340px, 460px);
+  gap: 42px;
+  align-items: end;
+  padding: 40px 0 28px;
+}
+
+.eyebrow {
+  display: inline-flex;
   align-items: center;
+  gap: 8px;
+  margin-bottom: 18px;
+  color: var(--accent-dark);
+  font-size: 13px;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: .08em;
 }
 
-.badge {
-  display: inline-block;
-  margin-bottom: 16px;
-  padding: 8px 12px;
-  border-radius: 999px;
-  border: 1px solid rgba(99, 230, 190, .35);
-  color: var(--accent);
-  background: rgba(99, 230, 190, .08);
+.lead {
+  max-width: 760px;
+  margin: 22px 0 0;
+  font-size: 20px;
 }
 
-.panel, .card {
-  border: 1px solid rgba(255, 255, 255, .09);
-  background: linear-gradient(180deg, rgba(255, 255, 255, .05), rgba(255, 255, 255, .02));
-  border-radius: 22px;
-  box-shadow: 0 24px 80px rgba(0, 0, 0, .28);
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 26px;
 }
 
-.panel { padding: 24px; }
-.card { padding: 20px; }
+.button {
+  display: inline-flex;
+  align-items: center;
+  min-height: 42px;
+  padding: 0 16px;
+  border-radius: 7px;
+  border: 1px solid var(--accent);
+  background: var(--accent);
+  color: #fff;
+  font-weight: 750;
+}
+
+.button.secondary {
+  background: transparent;
+  color: var(--accent-dark);
+}
 
 .grid {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 16px;
-  margin-top: 28px;
+  margin-top: 24px;
 }
 
-.flow {
+.two-col {
   display: grid;
-  grid-template-columns: repeat(6, 1fr);
-  gap: 10px;
-  margin-top: 18px;
+  grid-template-columns: 1fr 1fr;
+  gap: 22px;
 }
 
-.step {
-  position: relative;
-  min-height: 112px;
-  padding: 16px;
-  overflow: hidden;
-  border-radius: 18px;
-  border: 1px solid rgba(255, 255, 255, .09);
-  background: rgba(16, 36, 61, .72);
+.card, .panel {
+  border: 1px solid var(--line);
+  background: var(--surface);
+  border-radius: 8px;
 }
 
-.step::after {
-  content: "";
-  position: absolute;
-  inset: 0 auto 0 -45%;
-  width: 45%;
-  background: linear-gradient(90deg, transparent, rgba(99, 230, 190, .18), transparent);
-  animation: sweep 3s ease-in-out infinite;
-  animation-delay: calc(var(--i) * .2s);
+.card {
+  min-height: 150px;
+  padding: 20px;
 }
 
-.step b { display: block; margin-bottom: 8px; }
+.card p:last-child { margin-bottom: 0; }
+
+.panel {
+  padding: 28px;
+}
+
+.section { margin-top: 30px; }
+
+.doc-layout {
+  display: grid;
+  grid-template-columns: 250px minmax(0, 1fr);
+  gap: 28px;
+}
+
+.sidebar {
+  position: sticky;
+  top: 18px;
+  align-self: start;
+  padding: 18px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+}
+
+.sidebar a {
+  display: block;
+  padding: 8px 0;
+  color: var(--muted);
+}
 
 .terminal {
   overflow: hidden;
-  animation: float 5s ease-in-out infinite;
+  padding: 0;
+  background: var(--code-bg);
+  color: #e8e4dc;
 }
 
 .bar {
   display: flex;
   gap: 7px;
-  padding: 13px 16px;
-  background: rgba(255, 255, 255, .05);
-  border-bottom: 1px solid rgba(255, 255, 255, .08);
+  padding: 12px 14px;
+  border-bottom: 1px solid rgba(255, 255, 255, .1);
+  background: rgba(255, 255, 255, .04);
 }
 
-.dot { width: 11px; height: 11px; border-radius: 999px; }
-.red { background: #ff6b6b; }
-.yellow { background: var(--yellow); }
-.green { background: var(--accent); }
+.dot { width: 10px; height: 10px; border-radius: 999px; }
+.red { background: #ff6b5c; }
+.yellow { background: #f2be4d; }
+.green { background: #4bc47a; }
+
+.code-wrap {
+  position: relative;
+}
+
+.copy-code {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  border: 1px solid rgba(255, 255, 255, .18);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, .08);
+  color: #fff;
+  padding: 6px 9px;
+  cursor: pointer;
+}
 
 pre {
   margin: 0;
-  padding: 20px;
-  white-space: pre-wrap;
-  color: #d9e6ff;
-  line-height: 1.55;
+  padding: 22px;
+  overflow-x: auto;
+  color: #e8e4dc;
+  line-height: 1.6;
 }
 
-.pillrow { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 14px; }
+.pillrow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 16px;
+}
+
 .pill {
   padding: 7px 10px;
+  border: 1px solid var(--line);
   border-radius: 999px;
-  color: #cfe0ff;
-  background: rgba(110, 168, 254, .11);
-  border: 1px solid rgba(110, 168, 254, .22);
+  background: var(--surface-muted);
+  color: var(--muted);
   font-size: 13px;
+  font-weight: 650;
 }
 
-.section { margin-top: 34px; }
-.note { border-left: 4px solid var(--yellow); }
-
-svg text {
-  fill: var(--text);
-  font-family: Inter, Segoe UI, Arial, sans-serif;
-  font-size: 13px;
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 14px;
 }
 
-.pulse {
-  animation: pulse 2.4s ease-in-out infinite;
-  transform-origin: center;
+.table th, .table td {
+  padding: 12px;
+  border-bottom: 1px solid var(--line);
+  text-align: left;
+  vertical-align: top;
 }
 
-@keyframes sweep {
-  0% { left: -45%; }
-  65%, 100% { left: 110%; }
-}
+.table th { color: var(--text); }
 
-@keyframes float {
-  0%, 100% { transform: translateY(0); }
-  50% { transform: translateY(-10px); }
-}
-
-@keyframes pulse {
-  0%, 100% { opacity: .55; transform: scale(.98); }
-  50% { opacity: 1; transform: scale(1.04); }
+.note {
+  border-left: 4px solid var(--accent);
+  background: #fff7f3;
 }
 
 @media (max-width: 900px) {
-  .hero, .grid, .flow { grid-template-columns: 1fr; }
+  .hero, .grid, .two-col, .doc-layout { grid-template-columns: 1fr; }
+  .sidebar { position: static; }
 }

--- a/docs/human/index.html
+++ b/docs/human/index.html
@@ -8,15 +8,31 @@
 </head>
 <body>
   <main>
+    <header class="topbar">
+      <a class="brand" href="index.html"><span class="brand-mark"></span>Bifrost</a>
+      <nav class="nav">
+        <a href="01-criando-projeto.html">Inicio</a>
+        <a href="02-arquitetura.html">Arquitetura</a>
+        <a href="03-lifecycle.html">Lifecycle</a>
+        <a href="04-modulos.html">Modulos</a>
+        <a href="05-attributes-datatypes.html">Attributes</a>
+        <a href="06-deploy.html">Deploy</a>
+      </nav>
+    </header>
+
     <section class="hero">
       <div>
-        <span class="badge">Bifrost novo</span>
-        <h1>Framework Composer para criar APIs do zero.</h1>
-        <p>
-          Esta documentacao mostra como iniciar um backend em <code>api/</code>,
-          escolher modulos opcionais e usar attributes, DataTypes, rotas,
-          controllers e Docker.
+        <span class="eyebrow">Framework Composer para APIs</span>
+        <h1>Construa backends pequenos, modulares e previsiveis.</h1>
+        <p class="lead">
+          O Bifrost separa o core HTTP das integracoes opcionais. Projetos novos
+          comecam pelo skeleton e adicionam cache, fila, banco, storage e logs
+          somente quando precisam.
         </p>
+        <div class="actions">
+          <a class="button" href="01-criando-projeto.html">Criar projeto</a>
+          <a class="button secondary" href="04-modulos.html">Ver modulos</a>
+        </div>
       </div>
       <div class="panel terminal">
         <div class="bar"><span class="dot red"></span><span class="dot yellow"></span><span class="dot green"></span></div>
@@ -24,18 +40,20 @@
 cd api
 composer create-project bifrost/skeleton .
 cp .env.example .env
-docker compose up --build</pre>
+docker compose up --build
+curl http://localhost:8080/health</pre>
       </div>
     </section>
 
     <section class="grid">
-      <a class="card" href="01-criando-projeto.html"><h2>Criar Projeto</h2><p>Do zero ate o primeiro health check.</p></a>
-      <a class="card" href="02-arquitetura.html"><h2>Arquitetura</h2><p>Como framework, app e extensoes se encaixam.</p></a>
-      <a class="card" href="03-lifecycle.html"><h2>Lifecycle</h2><p>O caminho completo da request.</p></a>
-      <a class="card" href="04-modulos.html"><h2>Modulos</h2><p>Cache, fila, banco, storage e logs sob demanda.</p></a>
-      <a class="card" href="05-attributes-datatypes.html"><h2>Attributes e DataTypes</h2><p>Contratos HTTP e tipagem forte.</p></a>
-      <a class="card" href="06-deploy.html"><h2>Docker e Deploy</h2><p>Ambiente base e perfis opcionais.</p></a>
+      <a class="card" href="01-criando-projeto.html"><h2>Criar Projeto</h2><p>Instalacao do skeleton, estrutura inicial e primeiro health check.</p></a>
+      <a class="card" href="02-arquitetura.html"><h2>Arquitetura</h2><p>Core HTTP, container, extensoes e separacao por pacotes Composer.</p></a>
+      <a class="card" href="03-lifecycle.html"><h2>Lifecycle</h2><p>O caminho da request ate a response, incluindo middleware e controllers.</p></a>
+      <a class="card" href="04-modulos.html"><h2>Modulos</h2><p>Cache, fila, banco, Redis, storage e logs como dependencias opcionais.</p></a>
+      <a class="card" href="05-attributes-datatypes.html"><h2>Attributes e DataTypes</h2><p>Contratos HTTP declarativos e valores tipados reutilizaveis.</p></a>
+      <a class="card" href="06-deploy.html"><h2>Docker e Deploy</h2><p>Compose base, overlays e checks modulares.</p></a>
     </section>
   </main>
+  <script src="assets/app.js"></script>
 </body>
 </html>

--- a/docs/ias/composer-reference.md
+++ b/docs/ias/composer-reference.md
@@ -1,0 +1,119 @@
+# Referencia Composer do Bifrost para IAs
+
+## Objetivo
+
+Use esta referencia para criar e manter projetos novos com `bifrost/skeleton`
+e os pacotes em `packages/`. A documentacao descreve apenas a distribuicao
+Composer nova.
+
+## Instalacao
+
+```bash
+mkdir api
+cd api
+composer create-project bifrost/skeleton .
+cp .env.example .env
+docker compose up --build
+curl http://localhost:8080/health
+```
+
+## Lifecycle HTTP
+
+1. `public/index.php` cria `Request::fromGlobals()`.
+2. `bootstrap/app.php` cria `Application`, registra extensoes e rotas.
+3. `HttpKernel` executa middlewares e resolve a rota.
+4. `ControllerResolver` valida attributes e chama o handler.
+5. O resultado vira `Response`.
+6. `ResponseEmitter` envia status, headers e body.
+
+Toda resposta recebe `X-Request-Id`. Erros JSON tambem recebem `request_id`.
+
+## Controllers e Responses
+
+- Controllers recebem `Bifrost\Framework\Http\Request`.
+- Controllers retornam `Response`, array ou string.
+- Use helpers de `Response`: `json`, `text`, `created`, `notFound`,
+  `badRequest`, `internalServerError`.
+- `HttpException` padroniza erro HTTP com status, erros e headers.
+
+## Attributes
+
+- `Method`: valida verbo HTTP.
+- `RequiredFields` e `OptionalFields`: validam body.
+- `RequiredParams` e `OptionalParams`: validam query.
+- `Details`: metadados para introspeccao.
+- `Cache`: hook before/after usando `CacheStore`.
+- `Transaction`: hook before/after usando `TransactionManager`.
+
+Attributes de lifecycle implementam `BeforeRequestAttribute` ou
+`AfterResponseAttribute`.
+
+## DataTypes
+
+DataTypes implementam `Bifrost\Framework\Contracts\DataType`.
+
+Use quando o valor possui regra propria ou aparece em mais de um fluxo.
+Exemplos: `Email`, `Uuid`, `Cpf`, `Cnpj`, `Url`, `Json`, `Base64`,
+`FileName`, `FilePath`, `FolderName`, `FolderPath`, `StorageKey`.
+
+## Cache
+
+- Contrato: `Bifrost\Framework\Contracts\CacheStore`.
+- APCu: `bifrost/cache-apcu`.
+- Redis: `bifrost/cache-redis`.
+- `cache-redis` depende automaticamente de `bifrost/redis`.
+
+## Redis compartilhado
+
+`bifrost/redis` fornece:
+
+- `RedisConfig`
+- `RedisConnectionFactory`
+- `NativeRedisConnectionFactory`
+- `RedisConnectionManager`
+- `RedisExtension`
+
+Extensoes Redis devem pedir `RedisConnectionFactory` ao container. O manager
+reutiliza a mesma conexao para configuracoes iguais.
+
+## Fila e Worker
+
+- Contrato de fila: `Bifrost\Framework\Contracts\Queue`.
+- Redis: `bifrost/queue-redis`.
+- Worker: `bifrost/queue-worker`.
+- Tarefas usam `TaskPayload`, `TaskHandler`, `TaskRegistry`,
+  `QueueWorker` e `QueueWorkerCommand`.
+
+## Banco PDO
+
+- Contrato: `DatabaseConnectionFactory`.
+- Base: `bifrost/database-pdo`.
+- Drivers: `database-mysql`, `database-postgresql`, `database-sqlite`.
+- `PdoConnectionFactory` reutiliza conexoes por nome.
+- `PdoDatabase` tambem implementa `TransactionManager`.
+
+## Storage
+
+- Contrato: `Bifrost\Framework\Contracts\Storage`.
+- Local: `bifrost/storage-local`.
+- S3: `bifrost/storage-s3`.
+- `storage-s3` fornece `S3ClientFactory` e `S3ClientManager`.
+- Extensoes S3 devem usar `S3ClientFactory` em vez de criar `S3Client`
+  diretamente.
+
+## Logs
+
+- Contrato: `Bifrost\Framework\Contracts\LogWriter`.
+- Logger comum: `Bifrost\Framework\Logging\Logger`.
+- Destinos opcionais: `log-stdout`, `log-file`, `log-mongodb`.
+- O pacote MongoDB reutiliza o `MongoDB\Driver\Manager` dentro do writer.
+
+## Regra para novas extensoes
+
+1. Criar pacote em `packages/<nome>`.
+2. Depender de `bifrost/framework`.
+3. Implementar `Extension`.
+4. Registrar contratos no container.
+5. Encapsular fornecedor externo atras de factory/adapter.
+6. Criar testes do pacote.
+7. Atualizar `docs/human` e `docs/ias`.

--- a/docs/ias/framework-map.md
+++ b/docs/ias/framework-map.md
@@ -51,3 +51,5 @@
 - `bifrost/redis` fornece `RedisConnectionFactory` e `RedisConnectionManager`.
 - Extensoes Redis devem usar `RedisConnectionFactory` em vez de abrir conexoes diretamente.
 - Conexoes Redis equivalentes sao reutilizadas pelo `RedisConnectionManager`.
+- `bifrost/storage-s3` fornece `S3ClientFactory` e `S3ClientManager`.
+- Extensoes S3 devem usar `S3ClientFactory` em vez de criar `S3Client` diretamente.

--- a/docs/ias/framework-map.md
+++ b/docs/ias/framework-map.md
@@ -7,6 +7,7 @@
 - `HttpKernel`: lifecycle HTTP.
 - `Request`: metodo, path, query, body, headers e request-id.
 - `Response`: JSON/texto/status/headers e helpers HTTP comuns.
+- `HttpStatusCode`: enum de status HTTP comuns e classificacao por familia.
 - `Router` e `Route`: roteamento HTTP.
 - `ControllerResolver`: invoca controllers e valida attributes.
 - `HttpException`: excecao HTTP padronizada para respostas JSON com status, erros e headers.
@@ -20,6 +21,8 @@
 ## Attributes
 
 - `Method`
+- `Cache`
+- `Transaction`
 - `RequiredFields`
 - `OptionalFields`
 - `RequiredParams`
@@ -31,9 +34,20 @@
 
 - `Extension`
 - `CacheStore`
+- `LogWriter`
 - `Queue`
 - `DatabaseConnectionFactory`
 - `Storage`
 - `DataType`
 - `HttpAttribute`
 - `RequestValidatorAttribute`
+- `BeforeRequestAttribute`
+- `AfterResponseAttribute`
+- `TransactionManager`
+- `LogWriter`
+
+## Extensoes de Infraestrutura
+
+- `bifrost/redis` fornece `RedisConnectionFactory` e `RedisConnectionManager`.
+- Extensoes Redis devem usar `RedisConnectionFactory` em vez de abrir conexoes diretamente.
+- Conexoes Redis equivalentes sao reutilizadas pelo `RedisConnectionManager`.

--- a/docs/ias/index.md
+++ b/docs/ias/index.md
@@ -20,6 +20,7 @@ O foco e criar e manter projetos novos usando Composer, `bifrost/framework`,
 ## Mapa
 
 - `project-setup.md`: como um projeto novo nasce.
+- `composer-reference.md`: referencia operacional da distribuicao Composer.
 - `framework-map.md`: o que existe no framework.
 - `packages.md`: pacotes Composer disponiveis.
 - `extension-rules.md`: como criar extensoes.

--- a/docs/ias/packages.md
+++ b/docs/ias/packages.md
@@ -6,6 +6,7 @@
 | `bifrost/skeleton` | Projeto inicial |
 | `bifrost/datatypes` | DataTypes reutilizaveis |
 | `bifrost/cache-apcu` | Cache local APCu |
+| `bifrost/redis` | Conexao Redis reutilizavel para extensoes |
 | `bifrost/cache-redis` | Cache Redis |
 | `bifrost/queue-redis` | Fila Redis |
 | `bifrost/database-pdo` | Base PDO |
@@ -13,6 +14,8 @@
 | `bifrost/database-postgresql` | PostgreSQL |
 | `bifrost/storage-local` | Storage local |
 | `bifrost/storage-s3` | Storage S3 |
+| `bifrost/log-stdout` | Logs em stdout/stderr |
+| `bifrost/log-file` | Logs em arquivo |
 | `bifrost/log-mongodb` | Logs em MongoDB |
 
 ## Regra

--- a/packages/cache-apcu/src/ApcuCache.php
+++ b/packages/cache-apcu/src/ApcuCache.php
@@ -8,12 +8,19 @@ use Bifrost\Framework\Contracts\CacheStore;
 
 final class ApcuCache implements CacheStore
 {
+    /**
+     * @param string $prefix Prefixo aplicado nas chaves.
+     * @param int|null $defaultTtlSeconds TTL padrao em segundos.
+     */
     public function __construct(
         private readonly string $prefix = '',
         private readonly ?int $defaultTtlSeconds = null
     ) {
     }
 
+    /**
+     * Recupera um valor do cache APCu.
+     */
     public function get(string $key): mixed
     {
         $success = false;
@@ -22,6 +29,9 @@ final class ApcuCache implements CacheStore
         return $success ? $value : null;
     }
 
+    /**
+     * Armazena um valor no cache APCu.
+     */
     public function set(string $key, mixed $value, ?int $ttlSeconds = null): void
     {
         $ttlSeconds ??= $this->defaultTtlSeconds;
@@ -34,6 +44,9 @@ final class ApcuCache implements CacheStore
         apcu_store($this->cacheKey($key), $value, $ttlSeconds ?? 0);
     }
 
+    /**
+     * Remove uma chave do cache APCu.
+     */
     public function delete(string $key): void
     {
         apcu_delete($this->cacheKey($key));

--- a/packages/cache-apcu/src/ApcuCacheExtension.php
+++ b/packages/cache-apcu/src/ApcuCacheExtension.php
@@ -10,10 +10,16 @@ use Bifrost\Framework\Contracts\Extension;
 
 final class ApcuCacheExtension implements Extension
 {
+    /**
+     * @param array{prefix?: string, ttl?: int|null} $config
+     */
     public function __construct(private readonly array $config = [])
     {
     }
 
+    /**
+     * Registra o cache APCu como CacheStore.
+     */
     public function register(Application $application): void
     {
         $application->container()->bind(

--- a/packages/cache-redis/README.md
+++ b/packages/cache-redis/README.md
@@ -4,3 +4,7 @@ Adapter opcional de cache Redis para o Bifrost Framework.
 
 Registre `RedisCacheExtension` com as opcoes `host`, `port`, `timeout`,
 `password`, `database` e `prefix` conforme a necessidade da aplicacao.
+
+Este pacote usa `bifrost/redis` para abrir e reutilizar conexoes Redis. Se
+outra extensao registrar uma implementacao propria de `RedisConnectionFactory`,
+o cache passa a usar essa factory automaticamente.

--- a/packages/cache-redis/src/RedisCache.php
+++ b/packages/cache-redis/src/RedisCache.php
@@ -9,12 +9,19 @@ use Redis;
 
 final class RedisCache implements CacheStore
 {
+    /**
+     * @param Redis $redis Conexao Redis reutilizavel.
+     * @param string $prefix Prefixo aplicado nas chaves.
+     */
     public function __construct(
         private readonly Redis $redis,
         private readonly string $prefix = ''
     ) {
     }
 
+    /**
+     * Recupera um valor serializado do Redis.
+     */
     public function get(string $key): mixed
     {
         $value = $this->redis->get($this->cacheKey($key));
@@ -26,6 +33,9 @@ final class RedisCache implements CacheStore
         return unserialize($value, ['allowed_classes' => true]);
     }
 
+    /**
+     * Armazena um valor serializado no Redis.
+     */
     public function set(string $key, mixed $value, ?int $ttlSeconds = null): void
     {
         $key = $this->cacheKey($key);
@@ -44,6 +54,9 @@ final class RedisCache implements CacheStore
         $this->redis->setex($key, $ttlSeconds, $value);
     }
 
+    /**
+     * Remove uma chave do Redis.
+     */
     public function delete(string $key): void
     {
         $this->redis->del($this->cacheKey($key));

--- a/packages/cache-redis/src/RedisCacheExtension.php
+++ b/packages/cache-redis/src/RedisCacheExtension.php
@@ -17,12 +17,18 @@ final class RedisCacheExtension implements Extension
     private readonly RedisConfig $redisConfig;
     private readonly string $prefix;
 
+    /**
+     * @param array{host?: string, port?: int|string, timeout?: float|int|string, password?: string|null, database?: int|string|null, prefix?: string} $config
+     */
     public function __construct(private readonly array $config)
     {
         $this->redisConfig = RedisConfig::fromArray($config);
         $this->prefix = (string) ($config['prefix'] ?? '');
     }
 
+    /**
+     * Registra o cache Redis usando a factory Redis compartilhada.
+     */
     public function register(Application $application): void
     {
         RedisServiceRegistrar::register($application);

--- a/packages/cache-redis/src/RedisCacheExtension.php
+++ b/packages/cache-redis/src/RedisCacheExtension.php
@@ -4,50 +4,35 @@ declare(strict_types=1);
 
 namespace Bifrost\Extension\CacheRedis;
 
+use Bifrost\Extension\Redis\Contracts\RedisConnectionFactory;
+use Bifrost\Extension\Redis\RedisConfig;
+use Bifrost\Extension\Redis\RedisServiceRegistrar;
 use Bifrost\Framework\Application;
+use Bifrost\Framework\Container;
 use Bifrost\Framework\Contracts\CacheStore;
 use Bifrost\Framework\Contracts\Extension;
-use Redis;
-use RuntimeException;
 
 final class RedisCacheExtension implements Extension
 {
+    private readonly RedisConfig $redisConfig;
+    private readonly string $prefix;
+
     public function __construct(private readonly array $config)
     {
+        $this->redisConfig = RedisConfig::fromArray($config);
+        $this->prefix = (string) ($config['prefix'] ?? '');
     }
 
     public function register(Application $application): void
     {
+        RedisServiceRegistrar::register($application);
+
         $application->container()->bind(
             CacheStore::class,
-            fn (): RedisCache => new RedisCache(
-                redis: $this->connect(),
-                prefix: (string) ($this->config['prefix'] ?? '')
+            fn (Container $container): RedisCache => new RedisCache(
+                redis: $container->get(RedisConnectionFactory::class)->connect($this->redisConfig),
+                prefix: $this->prefix
             )
         );
-    }
-
-    private function connect(): Redis
-    {
-        $redis = new Redis();
-        $connected = $redis->connect(
-            (string) ($this->config['host'] ?? '127.0.0.1'),
-            (int) ($this->config['port'] ?? 6379),
-            (float) ($this->config['timeout'] ?? 0.0)
-        );
-
-        if (!$connected) {
-            throw new RuntimeException('Nao foi possivel conectar ao Redis de cache.');
-        }
-
-        if (isset($this->config['password'])) {
-            $redis->auth((string) $this->config['password']);
-        }
-
-        if (isset($this->config['database'])) {
-            $redis->select((int) $this->config['database']);
-        }
-
-        return $redis;
     }
 }

--- a/packages/cache-redis/tests/RedisCacheExtensionTest.php
+++ b/packages/cache-redis/tests/RedisCacheExtensionTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+use Bifrost\Extension\CacheRedis\RedisCache;
+use Bifrost\Extension\CacheRedis\RedisCacheExtension;
+use Bifrost\Extension\Redis\Contracts\RedisConnectionFactory;
+use Bifrost\Extension\Redis\RedisConfig;
+use Bifrost\Framework\Application;
+use Bifrost\Framework\Contracts\CacheStore;
+use PHPUnit\Framework\TestCase;
+
+final class RedisCacheExtensionTest extends TestCase
+{
+    public function testUsesSharedRedisConnectionFactory(): void
+    {
+        $factory = new CacheRedisCountingConnectionFactory();
+        $application = Application::create();
+        $application->container()->instance(RedisConnectionFactory::class, $factory);
+
+        $application->extend(new RedisCacheExtension([
+            'host' => 'redis',
+            'port' => 6379,
+            'database' => 0,
+            'prefix' => 'cache:',
+        ]));
+
+        self::assertInstanceOf(RedisCache::class, $application->container()->get(CacheStore::class));
+        self::assertSame(1, $factory->connections);
+        self::assertSame('redis', $factory->lastConfig?->host);
+        self::assertSame(0, $factory->lastConfig?->database);
+    }
+}
+
+final class CacheRedisCountingConnectionFactory implements RedisConnectionFactory
+{
+    public int $connections = 0;
+    public ?RedisConfig $lastConfig = null;
+
+    public function connect(RedisConfig $config): Redis
+    {
+        $this->connections++;
+        $this->lastConfig = $config;
+
+        return new Redis();
+    }
+}

--- a/packages/database-mysql/src/MySqlExtension.php
+++ b/packages/database-mysql/src/MySqlExtension.php
@@ -12,10 +12,16 @@ use InvalidArgumentException;
 
 final class MySqlExtension implements Extension
 {
+    /**
+     * @param array<string, mixed> $config Configuracao MySQL unica ou mapa de conexoes.
+     */
     public function __construct(private readonly array $config)
     {
     }
 
+    /**
+     * Registra a factory PDO configurada para MySQL.
+     */
     public function register(Application $application): void
     {
         $application->container()->bind(

--- a/packages/database-pdo/src/PdoConnectionFactory.php
+++ b/packages/database-pdo/src/PdoConnectionFactory.php
@@ -13,10 +13,16 @@ final class PdoConnectionFactory implements DatabaseConnectionFactory
     /** @var array<string, PDO> */
     private array $connections = [];
 
+    /**
+     * @param array<string, mixed> $config Configuracao PDO unica ou mapa de conexoes.
+     */
     public function __construct(private readonly array $config)
     {
     }
 
+    /**
+     * Retorna uma conexao PDO reutilizada pelo nome informado.
+     */
     public function connection(?string $name = null): PDO
     {
         $connectionName = $name ?? 'default';

--- a/packages/database-pdo/src/PdoDatabase.php
+++ b/packages/database-pdo/src/PdoDatabase.php
@@ -11,15 +11,24 @@ use PDOStatement;
 
 final class PdoDatabase implements TransactionManager
 {
+    /**
+     * @param PDO $connection Conexao PDO reutilizada pelo banco.
+     */
     public function __construct(private readonly PDO $connection)
     {
     }
 
+    /**
+     * Retorna a conexao PDO interna.
+     */
     public function connection(): PDO
     {
         return $this->connection;
     }
 
+    /**
+     * Retorna o driver PDO ativo.
+     */
     public function driver(): string
     {
         $driver = $this->connection->getAttribute(PDO::ATTR_DRIVER_NAME);
@@ -27,26 +36,43 @@ final class PdoDatabase implements TransactionManager
         return is_string($driver) ? $driver : 'unknown';
     }
 
+    /**
+     * Indica se o driver suporta RETURNING em inserts.
+     */
     public function supportsReturning(): bool
     {
         return $this->driver() === 'pgsql';
     }
 
+    /**
+     * Inicia uma transacao.
+     */
     public function begin(): bool
     {
         return $this->connection->beginTransaction();
     }
 
+    /**
+     * Desfaz a transacao atual.
+     */
     public function rollback(): bool
     {
         return $this->connection->rollBack();
     }
 
+    /**
+     * Confirma a transacao atual.
+     */
     public function commit(): bool
     {
         return $this->connection->commit();
     }
 
+    /**
+     * Executa SQL preparado com parametros.
+     *
+     * @param array<string, mixed> $params
+     */
     public function execute(string $sql, array $params = []): PDOStatement
     {
         $statement = $this->connection->prepare($sql);
@@ -55,11 +81,23 @@ final class PdoDatabase implements TransactionManager
         return $statement;
     }
 
+    /**
+     * Retorna todas as linhas como arrays associativos.
+     *
+     * @param array<string, mixed> $params
+     * @return list<array<string, mixed>>
+     */
     public function fetchAll(string $sql, array $params = []): array
     {
         return $this->execute($sql, $params)->fetchAll(PDO::FETCH_ASSOC);
     }
 
+    /**
+     * Retorna a primeira linha ou null.
+     *
+     * @param array<string, mixed> $params
+     * @return array<string, mixed>|null
+     */
     public function fetch(string $sql, array $params = []): ?array
     {
         $row = $this->execute($sql, $params)->fetch(PDO::FETCH_ASSOC);
@@ -67,6 +105,11 @@ final class PdoDatabase implements TransactionManager
         return $row === false ? null : $row;
     }
 
+    /**
+     * Retorna a primeira coluna da primeira linha.
+     *
+     * @param array<string, mixed> $params
+     */
     public function value(string $sql, array $params = []): mixed
     {
         $value = $this->execute($sql, $params)->fetchColumn();
@@ -74,6 +117,13 @@ final class PdoDatabase implements TransactionManager
         return $value === false ? null : $value;
     }
 
+    /**
+     * Monta e executa uma consulta SELECT simples.
+     *
+     * @param array<int, string>|string $columns
+     * @param array<string, mixed>|string|null $where
+     * @return list<array<string, mixed>>
+     */
     public function select(
         string $table,
         array|string $columns = '*',
@@ -100,6 +150,11 @@ final class PdoDatabase implements TransactionManager
         return $this->fetchAll($sql, $params);
     }
 
+    /**
+     * Insere uma linha e retorna o id gerado ou o valor de RETURNING.
+     *
+     * @param array<string, mixed> $data
+     */
     public function insert(string $table, array $data, ?string $returning = null): int|string
     {
         if ($data === []) {
@@ -122,6 +177,12 @@ final class PdoDatabase implements TransactionManager
         return $this->connection->lastInsertId();
     }
 
+    /**
+     * Atualiza linhas que batem com a condicao.
+     *
+     * @param array<string, mixed> $data
+     * @param array<string, mixed>|string $where
+     */
     public function update(string $table, array $data, array|string $where): int
     {
         if ($data === []) {
@@ -147,6 +208,11 @@ final class PdoDatabase implements TransactionManager
         return $statement->rowCount();
     }
 
+    /**
+     * Remove linhas que batem com a condicao.
+     *
+     * @param array<string, mixed>|string $where
+     */
     public function delete(string $table, array|string $where): int
     {
         $params = [];
@@ -156,6 +222,11 @@ final class PdoDatabase implements TransactionManager
         return $statement->rowCount();
     }
 
+    /**
+     * Verifica se existe ao menos uma linha para a condicao.
+     *
+     * @param array<string, mixed>|string|null $where
+     */
     public function exists(string $table, array|string|null $where = null): bool
     {
         $params = [];

--- a/packages/database-pdo/src/PdoExtension.php
+++ b/packages/database-pdo/src/PdoExtension.php
@@ -12,10 +12,16 @@ use Bifrost\Framework\Contracts\TransactionManager;
 
 final class PdoExtension implements Extension
 {
+    /**
+     * @param array<string, mixed> $config Configuracao PDO unica ou mapa de conexoes.
+     */
     public function __construct(private readonly array $config)
     {
     }
 
+    /**
+     * Registra factory PDO, banco padrao e gerenciador de transacao.
+     */
     public function register(Application $application): void
     {
         $factory = new PdoConnectionFactory(config: $this->config);

--- a/packages/database-postgresql/src/PostgreSqlExtension.php
+++ b/packages/database-postgresql/src/PostgreSqlExtension.php
@@ -12,10 +12,16 @@ use InvalidArgumentException;
 
 final class PostgreSqlExtension implements Extension
 {
+    /**
+     * @param array<string, mixed> $config Configuracao PostgreSQL unica ou mapa de conexoes.
+     */
     public function __construct(private readonly array $config)
     {
     }
 
+    /**
+     * Registra a factory PDO configurada para PostgreSQL.
+     */
     public function register(Application $application): void
     {
         $application->container()->bind(

--- a/packages/database-sqlite/src/SqliteExtension.php
+++ b/packages/database-sqlite/src/SqliteExtension.php
@@ -14,10 +14,16 @@ use InvalidArgumentException;
 
 final class SqliteExtension implements Extension
 {
+    /**
+     * @param array<string, mixed> $config Configuracao SQLite unica ou mapa de conexoes.
+     */
     public function __construct(private readonly array $config)
     {
     }
 
+    /**
+     * Registra a factory PDO configurada para SQLite.
+     */
     public function register(Application $application): void
     {
         $factory = new PdoConnectionFactory(config: $this->pdoConfig());

--- a/packages/datatypes/src/AbstractDataType.php
+++ b/packages/datatypes/src/AbstractDataType.php
@@ -14,6 +14,9 @@ abstract readonly class AbstractDataType implements DataType, JsonSerializable
     {
     }
 
+    /**
+     * Cria e valida uma instancia do DataType.
+     */
     public static function from(mixed $value): static
     {
         if (!static::isValid($value)) {
@@ -23,16 +26,25 @@ abstract readonly class AbstractDataType implements DataType, JsonSerializable
         return new static(static::normalize($value));
     }
 
+    /**
+     * Retorna o valor normalizado.
+     */
     public function value(): mixed
     {
         return $this->value;
     }
 
+    /**
+     * Retorna o valor serializavel.
+     */
     public function jsonSerialize(): mixed
     {
         return $this->value();
     }
 
+    /**
+     * Retorna a representacao textual do valor.
+     */
     public function __toString(): string
     {
         return (string) $this->value();

--- a/packages/datatypes/src/Base64.php
+++ b/packages/datatypes/src/Base64.php
@@ -6,6 +6,9 @@ namespace Bifrost\DataTypes;
 
 final readonly class Base64 extends AbstractDataType
 {
+    /**
+     * Verifica se o valor e uma string Base64 valida.
+     */
     public static function isValid(mixed $value): bool
     {
         return is_string($value) && base64_decode($value, true) !== false;

--- a/packages/datatypes/src/Brazil/Cnpj.php
+++ b/packages/datatypes/src/Brazil/Cnpj.php
@@ -8,6 +8,9 @@ use Bifrost\DataTypes\AbstractDataType;
 
 final readonly class Cnpj extends AbstractDataType
 {
+    /**
+     * Verifica se o valor e um CNPJ valido.
+     */
     public static function isValid(mixed $value): bool
     {
         $digits = self::digits($value);

--- a/packages/datatypes/src/Brazil/Cpf.php
+++ b/packages/datatypes/src/Brazil/Cpf.php
@@ -8,6 +8,9 @@ use Bifrost\DataTypes\AbstractDataType;
 
 final readonly class Cpf extends AbstractDataType
 {
+    /**
+     * Verifica se o valor e um CPF valido.
+     */
     public static function isValid(mixed $value): bool
     {
         $digits = self::digits($value);

--- a/packages/datatypes/src/DateTime.php
+++ b/packages/datatypes/src/DateTime.php
@@ -11,11 +11,17 @@ use InvalidArgumentException;
 
 final readonly class DateTime extends AbstractDataType
 {
+    /**
+     * Cria um DateTime com o instante atual.
+     */
     public static function now(): self
     {
         return self::from('now');
     }
 
+    /**
+     * Verifica se o valor pode ser convertido para data e hora.
+     */
     public static function isValid(mixed $value): bool
     {
         if ($value instanceof DateTimeInterface) {
@@ -35,6 +41,9 @@ final readonly class DateTime extends AbstractDataType
         return true;
     }
 
+    /**
+     * Garante que a data e hora representada esta no futuro.
+     */
     public function assertFuture(): void
     {
         if (new DateTimeImmutable((string) $this->value()) <= new DateTimeImmutable()) {

--- a/packages/datatypes/src/Email.php
+++ b/packages/datatypes/src/Email.php
@@ -6,6 +6,9 @@ namespace Bifrost\DataTypes;
 
 final readonly class Email extends AbstractDataType
 {
+    /**
+     * Verifica se o valor e um e-mail valido.
+     */
     public static function isValid(mixed $value): bool
     {
         return is_string($value) && filter_var($value, FILTER_VALIDATE_EMAIL) !== false;

--- a/packages/datatypes/src/Filesystem/FileName.php
+++ b/packages/datatypes/src/Filesystem/FileName.php
@@ -8,6 +8,9 @@ use Bifrost\DataTypes\AbstractDataType;
 
 final readonly class FileName extends AbstractDataType
 {
+    /**
+     * Verifica se o valor e um nome de arquivo valido.
+     */
     public static function isValid(mixed $value): bool
     {
         if (!is_string($value) || $value === '' || strlen($value) > 255) {

--- a/packages/datatypes/src/Filesystem/FilePath.php
+++ b/packages/datatypes/src/Filesystem/FilePath.php
@@ -8,6 +8,9 @@ use Bifrost\DataTypes\AbstractDataType;
 
 readonly class FilePath extends AbstractDataType
 {
+    /**
+     * Verifica se o valor e um caminho de arquivo valido.
+     */
     public static function isValid(mixed $value): bool
     {
         if (!is_string($value) || $value === '') {

--- a/packages/datatypes/src/Filesystem/FolderName.php
+++ b/packages/datatypes/src/Filesystem/FolderName.php
@@ -8,6 +8,9 @@ use Bifrost\DataTypes\AbstractDataType;
 
 final readonly class FolderName extends AbstractDataType
 {
+    /**
+     * Verifica se o valor e um nome de pasta valido.
+     */
     public static function isValid(mixed $value): bool
     {
         return is_string($value)

--- a/packages/datatypes/src/Filesystem/FolderPath.php
+++ b/packages/datatypes/src/Filesystem/FolderPath.php
@@ -8,6 +8,9 @@ use Bifrost\DataTypes\AbstractDataType;
 
 final readonly class FolderPath extends AbstractDataType
 {
+    /**
+     * Verifica se o valor e um caminho de pasta valido.
+     */
     public static function isValid(mixed $value): bool
     {
         if (!is_string($value) || $value === '') {

--- a/packages/datatypes/src/Json.php
+++ b/packages/datatypes/src/Json.php
@@ -6,6 +6,9 @@ namespace Bifrost\DataTypes;
 
 final readonly class Json extends AbstractDataType
 {
+    /**
+     * Verifica se o valor e uma string JSON valida.
+     */
     public static function isValid(mixed $value): bool
     {
         if (!is_string($value) || trim($value) === '') {

--- a/packages/datatypes/src/Storage/StorageKey.php
+++ b/packages/datatypes/src/Storage/StorageKey.php
@@ -13,6 +13,9 @@ final readonly class StorageKey extends FilePath
         return str_replace('\\', '/', trim((string) $value));
     }
 
+    /**
+     * Verifica se o valor e uma chave relativa valida para storage.
+     */
     public static function isValid(mixed $value): bool
     {
         if (!is_string($value)) {

--- a/packages/datatypes/src/Url.php
+++ b/packages/datatypes/src/Url.php
@@ -6,6 +6,9 @@ namespace Bifrost\DataTypes;
 
 final readonly class Url extends AbstractDataType
 {
+    /**
+     * Verifica se o valor e uma URL valida.
+     */
     public static function isValid(mixed $value): bool
     {
         return is_string($value) && filter_var($value, FILTER_VALIDATE_URL) !== false;

--- a/packages/datatypes/src/Uuid.php
+++ b/packages/datatypes/src/Uuid.php
@@ -6,6 +6,9 @@ namespace Bifrost\DataTypes;
 
 final readonly class Uuid extends AbstractDataType
 {
+    /**
+     * Gera um UUID v4 valido.
+     */
     public static function generate(): self
     {
         $bytes = random_bytes(16);
@@ -23,6 +26,9 @@ final readonly class Uuid extends AbstractDataType
         ));
     }
 
+    /**
+     * Verifica se o valor e um UUID valido.
+     */
     public static function isValid(mixed $value): bool
     {
         return is_string($value)

--- a/packages/framework/src/Http/HttpKernel.php
+++ b/packages/framework/src/Http/HttpKernel.php
@@ -21,6 +21,11 @@ final class HttpKernel
     /** @var list<callable> */
     private array $middleware = [];
 
+    /**
+     * @param Router $router Roteador HTTP da aplicacao.
+     * @param ControllerResolver $controllerResolver Resolvedor de handlers e controllers.
+     * @param bool $debug Quando true, respostas 500 podem expor a mensagem da excecao.
+     */
     public function __construct(
         private readonly Router $router,
         private readonly ControllerResolver $controllerResolver,

--- a/packages/framework/src/Logging/Logger.php
+++ b/packages/framework/src/Logging/Logger.php
@@ -22,6 +22,11 @@ final class Logger
     /** @var Closure(): string */
     private readonly Closure $requestIdResolver;
 
+    /**
+     * @param LogWriter $writer Destino estruturado do log.
+     * @param callable|null $timestampResolver Resolver opcional de timestamp, usado em testes.
+     * @param callable|null $requestIdResolver Resolver opcional de request-id, usado em testes.
+     */
     public function __construct(
         private readonly LogWriter $writer,
         ?callable $timestampResolver = null,

--- a/packages/log-file/src/FileLogConfig.php
+++ b/packages/log-file/src/FileLogConfig.php
@@ -12,6 +12,11 @@ final class FileLogConfig
     {
     }
 
+    /**
+     * Cria a configuracao a partir de array.
+     *
+     * @param array{path?: string} $config
+     */
     public static function fromArray(array $config): self
     {
         $path = $config['path'] ?? null;
@@ -22,6 +27,9 @@ final class FileLogConfig
         return new self(trim($path));
     }
 
+    /**
+     * Retorna o caminho do arquivo de log.
+     */
     public function path(): string
     {
         return $this->path;

--- a/packages/log-file/src/FileLogExtension.php
+++ b/packages/log-file/src/FileLogExtension.php
@@ -18,6 +18,10 @@ final class FileLogExtension implements Extension
     /** @var Closure(FileLogConfig): LogWriter|null */
     private readonly ?Closure $writerFactory;
 
+    /**
+     * @param array{path?: string} $config Configuracao do arquivo de log.
+     * @param callable|null $writerFactory Factory opcional para testes ou integracao customizada.
+     */
     public function __construct(array $config, ?callable $writerFactory = null)
     {
         $this->config = FileLogConfig::fromArray($config);
@@ -26,6 +30,9 @@ final class FileLogExtension implements Extension
             : Closure::fromCallable($writerFactory);
     }
 
+    /**
+     * Registra o writer em arquivo e o logger estruturado.
+     */
     public function register(Application $application): void
     {
         $application->container()->bind(

--- a/packages/log-file/src/FileLogWriter.php
+++ b/packages/log-file/src/FileLogWriter.php
@@ -10,6 +10,9 @@ use RuntimeException;
 
 final class FileLogWriter implements LogWriter
 {
+    /**
+     * @param FileLogConfig $config Configuracao do arquivo de destino.
+     */
     public function __construct(private readonly FileLogConfig $config)
     {
     }

--- a/packages/log-mongodb/src/MongoLogConfig.php
+++ b/packages/log-mongodb/src/MongoLogConfig.php
@@ -15,6 +15,11 @@ final class MongoLogConfig
     ) {
     }
 
+    /**
+     * Cria a configuracao a partir de array.
+     *
+     * @param array<string, mixed> $config
+     */
     public static function fromArray(array $config): self
     {
         $database = self::optionalString($config['database'] ?? null);
@@ -31,21 +36,33 @@ final class MongoLogConfig
         );
     }
 
+    /**
+     * Retorna a URI de conexao MongoDB.
+     */
     public function uri(): string
     {
         return $this->uri;
     }
 
+    /**
+     * Retorna o banco onde os logs serao gravados.
+     */
     public function database(): string
     {
         return $this->database;
     }
 
+    /**
+     * Retorna a collection onde os logs serao gravados.
+     */
     public function collection(): string
     {
         return $this->collection;
     }
 
+    /**
+     * Retorna namespace MongoDB no formato database.collection.
+     */
     public function collectionNamespace(): string
     {
         return "{$this->database}.{$this->collection}";

--- a/packages/log-mongodb/src/MongoLogExtension.php
+++ b/packages/log-mongodb/src/MongoLogExtension.php
@@ -18,6 +18,10 @@ final class MongoLogExtension implements Extension
     /** @var Closure(MongoLogConfig): LogWriter|null */
     private readonly ?Closure $writerFactory;
 
+    /**
+     * @param array<string, mixed> $config Configuracao MongoDB.
+     * @param callable|null $writerFactory Factory opcional para testes ou integracao customizada.
+     */
     public function __construct(array $config, ?callable $writerFactory = null)
     {
         $this->config = MongoLogConfig::fromArray($config);
@@ -26,6 +30,9 @@ final class MongoLogExtension implements Extension
             : Closure::fromCallable($writerFactory);
     }
 
+    /**
+     * Registra o writer MongoDB e o logger estruturado.
+     */
     public function register(Application $application): void
     {
         $application->container()->bind(

--- a/packages/log-mongodb/src/MongoLogWriter.php
+++ b/packages/log-mongodb/src/MongoLogWriter.php
@@ -16,6 +16,10 @@ final class MongoLogWriter implements LogWriter
     /** @var Closure(string, array): void */
     private readonly Closure $insertDocument;
 
+    /**
+     * @param MongoLogConfig $config Configuracao do destino MongoDB.
+     * @param callable $insertDocument Funcao que insere o documento.
+     */
     public function __construct(
         private readonly MongoLogConfig $config,
         callable $insertDocument
@@ -23,6 +27,9 @@ final class MongoLogWriter implements LogWriter
         $this->insertDocument = Closure::fromCallable($insertDocument);
     }
 
+    /**
+     * Cria um writer conectado ao MongoDB.
+     */
     public static function connect(MongoLogConfig $config): self
     {
         if (!class_exists(Manager::class)) {
@@ -48,6 +55,11 @@ final class MongoLogWriter implements LogWriter
         );
     }
 
+    /**
+     * Grava uma entrada de log no MongoDB.
+     *
+     * @param array<string, mixed> $entry
+     */
     public function write(array $entry): void
     {
         ($this->insertDocument)($this->config->collectionNamespace(), $entry);

--- a/packages/log-stdout/src/StdoutLogConfig.php
+++ b/packages/log-stdout/src/StdoutLogConfig.php
@@ -12,6 +12,11 @@ final class StdoutLogConfig
     {
     }
 
+    /**
+     * Cria a configuracao a partir de array.
+     *
+     * @param array{stream?: string} $config
+     */
     public static function fromArray(array $config = []): self
     {
         $stream = $config['stream'] ?? 'stdout';
@@ -22,6 +27,9 @@ final class StdoutLogConfig
         return new self($stream);
     }
 
+    /**
+     * Retorna o stream de saida usado pelo writer.
+     */
     public function stream(): string
     {
         return $this->stream;

--- a/packages/log-stdout/src/StdoutLogExtension.php
+++ b/packages/log-stdout/src/StdoutLogExtension.php
@@ -18,6 +18,10 @@ final class StdoutLogExtension implements Extension
     /** @var Closure(StdoutLogConfig): LogWriter|null */
     private readonly ?Closure $writerFactory;
 
+    /**
+     * @param array{stream?: string} $config Configuracao do stream stdout/stderr.
+     * @param callable|null $writerFactory Factory opcional para testes ou integracao customizada.
+     */
     public function __construct(array $config = [], ?callable $writerFactory = null)
     {
         $this->config = StdoutLogConfig::fromArray($config);
@@ -26,6 +30,9 @@ final class StdoutLogExtension implements Extension
             : Closure::fromCallable($writerFactory);
     }
 
+    /**
+     * Registra o writer stdout/stderr e o logger estruturado.
+     */
     public function register(Application $application): void
     {
         $application->container()->bind(

--- a/packages/log-stdout/src/StdoutLogWriter.php
+++ b/packages/log-stdout/src/StdoutLogWriter.php
@@ -13,6 +13,10 @@ final class StdoutLogWriter implements LogWriter
     /** @var Closure(string): void */
     private readonly Closure $writeLine;
 
+    /**
+     * @param StdoutLogConfig $config Configuracao do stream.
+     * @param callable|null $writeLine Escritor de linha opcional para testes.
+     */
     public function __construct(StdoutLogConfig $config, ?callable $writeLine = null)
     {
         $this->writeLine = Closure::fromCallable(

--- a/packages/queue-redis/README.md
+++ b/packages/queue-redis/README.md
@@ -4,3 +4,7 @@ Adapter opcional de fila Redis para o Bifrost Framework.
 
 Registre `RedisQueueExtension` com as opcoes `host`, `port`, `timeout`,
 `password`, `database` e `prefix` conforme a necessidade da aplicacao.
+
+Este pacote usa `bifrost/redis` para abrir e reutilizar conexoes Redis. Se
+outra extensao registrar uma implementacao propria de `RedisConnectionFactory`,
+a fila passa a usar essa factory automaticamente.

--- a/packages/queue-redis/composer.json
+++ b/packages/queue-redis/composer.json
@@ -6,6 +6,7 @@
   "require": {
     "php": ">=8.1",
     "bifrost/framework": "^1.0",
+    "bifrost/redis": "^1.0",
     "ext-redis": "*"
   },
   "autoload": {

--- a/packages/queue-redis/src/RedisQueue.php
+++ b/packages/queue-redis/src/RedisQueue.php
@@ -10,17 +10,31 @@ use UnexpectedValueException;
 
 final class RedisQueue implements Queue
 {
+    /**
+     * @param Redis $redis Conexao Redis reutilizavel.
+     * @param string $prefix Prefixo aplicado nas filas.
+     */
     public function __construct(
         private readonly Redis $redis,
         private readonly string $prefix = ''
     ) {
     }
 
+    /**
+     * Enfileira um payload serializavel.
+     *
+     * @param array<string, mixed> $payload
+     */
     public function push(string $queue, array $payload): void
     {
         $this->redis->rPush($this->queueKey($queue), serialize($payload));
     }
 
+    /**
+     * Remove e retorna o proximo payload da fila.
+     *
+     * @return array<string, mixed>|null
+     */
     public function pop(string $queue): ?array
     {
         $payload = $this->redis->lPop($this->queueKey($queue));

--- a/packages/queue-redis/src/RedisQueueExtension.php
+++ b/packages/queue-redis/src/RedisQueueExtension.php
@@ -17,12 +17,18 @@ final class RedisQueueExtension implements Extension
     private readonly RedisConfig $redisConfig;
     private readonly string $prefix;
 
+    /**
+     * @param array{host?: string, port?: int|string, timeout?: float|int|string, password?: string|null, database?: int|string|null, prefix?: string} $config
+     */
     public function __construct(private readonly array $config)
     {
         $this->redisConfig = RedisConfig::fromArray($config);
         $this->prefix = (string) ($config['prefix'] ?? '');
     }
 
+    /**
+     * Registra a fila Redis usando a factory Redis compartilhada.
+     */
     public function register(Application $application): void
     {
         RedisServiceRegistrar::register($application);

--- a/packages/queue-redis/src/RedisQueueExtension.php
+++ b/packages/queue-redis/src/RedisQueueExtension.php
@@ -4,50 +4,35 @@ declare(strict_types=1);
 
 namespace Bifrost\Extension\QueueRedis;
 
+use Bifrost\Extension\Redis\Contracts\RedisConnectionFactory;
+use Bifrost\Extension\Redis\RedisConfig;
+use Bifrost\Extension\Redis\RedisServiceRegistrar;
 use Bifrost\Framework\Application;
+use Bifrost\Framework\Container;
 use Bifrost\Framework\Contracts\Extension;
 use Bifrost\Framework\Contracts\Queue;
-use Redis;
-use RuntimeException;
 
 final class RedisQueueExtension implements Extension
 {
+    private readonly RedisConfig $redisConfig;
+    private readonly string $prefix;
+
     public function __construct(private readonly array $config)
     {
+        $this->redisConfig = RedisConfig::fromArray($config);
+        $this->prefix = (string) ($config['prefix'] ?? '');
     }
 
     public function register(Application $application): void
     {
+        RedisServiceRegistrar::register($application);
+
         $application->container()->bind(
             Queue::class,
-            fn (): RedisQueue => new RedisQueue(
-                redis: $this->connect(),
-                prefix: (string) ($this->config['prefix'] ?? '')
+            fn (Container $container): RedisQueue => new RedisQueue(
+                redis: $container->get(RedisConnectionFactory::class)->connect($this->redisConfig),
+                prefix: $this->prefix
             )
         );
-    }
-
-    private function connect(): Redis
-    {
-        $redis = new Redis();
-        $connected = $redis->connect(
-            (string) ($this->config['host'] ?? '127.0.0.1'),
-            (int) ($this->config['port'] ?? 6379),
-            (float) ($this->config['timeout'] ?? 0.0)
-        );
-
-        if (!$connected) {
-            throw new RuntimeException('Nao foi possivel conectar ao Redis de fila.');
-        }
-
-        if (isset($this->config['password'])) {
-            $redis->auth((string) $this->config['password']);
-        }
-
-        if (isset($this->config['database'])) {
-            $redis->select((int) $this->config['database']);
-        }
-
-        return $redis;
     }
 }

--- a/packages/queue-redis/tests/RedisQueueExtensionTest.php
+++ b/packages/queue-redis/tests/RedisQueueExtensionTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+use Bifrost\Extension\QueueRedis\RedisQueue;
+use Bifrost\Extension\QueueRedis\RedisQueueExtension;
+use Bifrost\Extension\Redis\Contracts\RedisConnectionFactory;
+use Bifrost\Extension\Redis\RedisConfig;
+use Bifrost\Framework\Application;
+use Bifrost\Framework\Contracts\Queue;
+use PHPUnit\Framework\TestCase;
+
+final class RedisQueueExtensionTest extends TestCase
+{
+    public function testUsesSharedRedisConnectionFactory(): void
+    {
+        $factory = new QueueRedisCountingConnectionFactory();
+        $application = Application::create();
+        $application->container()->instance(RedisConnectionFactory::class, $factory);
+
+        $application->extend(new RedisQueueExtension([
+            'host' => 'redis',
+            'port' => 6379,
+            'database' => 0,
+            'prefix' => 'queue:',
+        ]));
+
+        self::assertInstanceOf(RedisQueue::class, $application->container()->get(Queue::class));
+        self::assertSame(1, $factory->connections);
+        self::assertSame('redis', $factory->lastConfig?->host);
+        self::assertSame(0, $factory->lastConfig?->database);
+    }
+}
+
+final class QueueRedisCountingConnectionFactory implements RedisConnectionFactory
+{
+    public int $connections = 0;
+    public ?RedisConfig $lastConfig = null;
+
+    public function connect(RedisConfig $config): Redis
+    {
+        $this->connections++;
+        $this->lastConfig = $config;
+
+        return new Redis();
+    }
+}

--- a/packages/queue-worker/src/QueueWorker.php
+++ b/packages/queue-worker/src/QueueWorker.php
@@ -9,12 +9,21 @@ use Throwable;
 
 final class QueueWorker
 {
+    /**
+     * @param Queue $queue Fila usada para buscar e reenfileirar tarefas.
+     * @param TaskRegistry $tasks Registro de handlers disponiveis.
+     */
     public function __construct(
         private readonly Queue $queue,
         private readonly TaskRegistry $tasks
     ) {
     }
 
+    /**
+     * Processa uma unica mensagem da fila.
+     *
+     * @param string $queue Nome da fila consumida.
+     */
     public function workOnce(string $queue): WorkerResult
     {
         $payload = $this->queue->pop($queue);

--- a/packages/queue-worker/src/QueueWorkerCommand.php
+++ b/packages/queue-worker/src/QueueWorkerCommand.php
@@ -6,12 +6,22 @@ namespace Bifrost\Extension\QueueWorker;
 
 final class QueueWorkerCommand
 {
+    /**
+     * @param QueueWorker $worker Worker responsavel pelo processamento.
+     * @param int $defaultSleepSeconds Pausa padrao quando a fila estiver vazia.
+     */
     public function __construct(
         private readonly QueueWorker $worker,
         private readonly int $defaultSleepSeconds = 1
     ) {
     }
 
+    /**
+     * Executa o loop de consumo da fila.
+     *
+     * @param list<string> $argv Argumentos de linha de comando.
+     * @return int Codigo de saida do processo.
+     */
     public function run(array $argv): int
     {
         $options = $this->options($argv);

--- a/packages/queue-worker/src/TaskHandler.php
+++ b/packages/queue-worker/src/TaskHandler.php
@@ -6,5 +6,8 @@ namespace Bifrost\Extension\QueueWorker;
 
 interface TaskHandler
 {
+    /**
+     * Processa uma tarefa recebida do worker.
+     */
     public function handle(TaskPayload $payload): void;
 }

--- a/packages/queue-worker/src/TaskPayload.php
+++ b/packages/queue-worker/src/TaskPayload.php
@@ -9,6 +9,12 @@ use JsonSerializable;
 
 final class TaskPayload implements JsonSerializable
 {
+    /**
+     * @param string $task Nome pesquisavel da tarefa.
+     * @param array<string, mixed> $data Dados serializaveis da tarefa.
+     * @param int $attempts Quantidade de tentativas ja registradas.
+     * @param int $maxAttempts Limite maximo de tentativas.
+     */
     public function __construct(
         private readonly string $task,
         private readonly array $data = [],
@@ -30,6 +36,11 @@ final class TaskPayload implements JsonSerializable
         self::assertSerializableArray($this->data);
     }
 
+    /**
+     * Cria um payload validado a partir dos dados vindos da fila.
+     *
+     * @param array<string, mixed> $payload
+     */
     public static function fromArray(array $payload): self
     {
         $task = $payload['task'] ?? null;
@@ -50,26 +61,43 @@ final class TaskPayload implements JsonSerializable
         );
     }
 
+    /**
+     * Retorna o nome da tarefa.
+     */
     public function task(): string
     {
         return $this->task;
     }
 
+    /**
+     * Retorna os dados serializaveis da tarefa.
+     *
+     * @return array<string, mixed>
+     */
     public function data(): array
     {
         return $this->data;
     }
 
+    /**
+     * Retorna a quantidade de tentativas ja feitas.
+     */
     public function attempts(): int
     {
         return $this->attempts;
     }
 
+    /**
+     * Retorna o limite maximo de tentativas.
+     */
     public function maxAttempts(): int
     {
         return $this->maxAttempts;
     }
 
+    /**
+     * Retorna uma nova instancia com uma falha registrada.
+     */
     public function withRecordedFailure(): self
     {
         return new self(
@@ -80,11 +108,19 @@ final class TaskPayload implements JsonSerializable
         );
     }
 
+    /**
+     * Indica se a tarefa ainda pode ser reenfileirada.
+     */
     public function canRetry(): bool
     {
         return $this->attempts < $this->maxAttempts;
     }
 
+    /**
+     * Serializa o payload para gravacao na fila.
+     *
+     * @return array{task: string, data: array<string, mixed>, attempts: int, max_attempts: int}
+     */
     public function toArray(): array
     {
         return [
@@ -95,6 +131,9 @@ final class TaskPayload implements JsonSerializable
         ];
     }
 
+    /**
+     * @return array{task: string, data: array<string, mixed>, attempts: int, max_attempts: int}
+     */
     public function jsonSerialize(): array
     {
         return $this->toArray();

--- a/packages/queue-worker/src/TaskRegistry.php
+++ b/packages/queue-worker/src/TaskRegistry.php
@@ -11,6 +11,12 @@ final class TaskRegistry
     /** @var array<string, TaskHandler|callable> */
     private array $handlers = [];
 
+    /**
+     * Registra um handler para um nome de tarefa.
+     *
+     * @param string $task Nome pesquisavel da tarefa.
+     * @param TaskHandler|callable $handler Handler invocavel pelo worker.
+     */
     public function add(string $task, TaskHandler|callable $handler): self
     {
         if ($task === '') {
@@ -22,6 +28,9 @@ final class TaskRegistry
         return $this;
     }
 
+    /**
+     * Executa o handler registrado para o payload informado.
+     */
     public function handle(TaskPayload $payload): void
     {
         $handler = $this->handlers[$payload->task()] ?? null;

--- a/packages/queue-worker/src/WorkerResult.php
+++ b/packages/queue-worker/src/WorkerResult.php
@@ -20,51 +20,81 @@ final class WorkerResult
     ) {
     }
 
+    /**
+     * Cria resultado para fila vazia.
+     */
     public static function idle(): self
     {
         return new self(self::IDLE);
     }
 
+    /**
+     * Cria resultado para tarefa processada com sucesso.
+     */
     public static function processed(TaskPayload $payload): self
     {
         return new self(self::PROCESSED, $payload);
     }
 
+    /**
+     * Cria resultado para tarefa reenfileirada apos falha.
+     */
     public static function retried(TaskPayload $payload, Throwable $error): self
     {
         return new self(self::RETRIED, $payload, $error);
     }
 
+    /**
+     * Cria resultado para falha definitiva.
+     */
     public static function failed(TaskPayload $payload, Throwable $error): self
     {
         return new self(self::FAILED, $payload, $error);
     }
 
+    /**
+     * Indica que nenhuma tarefa foi encontrada.
+     */
     public function isIdle(): bool
     {
         return $this->status === self::IDLE;
     }
 
+    /**
+     * Indica que a tarefa foi processada.
+     */
     public function isProcessed(): bool
     {
         return $this->status === self::PROCESSED;
     }
 
+    /**
+     * Indica que a tarefa foi reenfileirada.
+     */
     public function isRetried(): bool
     {
         return $this->status === self::RETRIED;
     }
 
+    /**
+     * Indica que a tarefa falhou definitivamente.
+     */
     public function isFailed(): bool
     {
         return $this->status === self::FAILED;
     }
 
+    /**
+     * Retorna o payload relacionado ao resultado, quando existir.
+     */
     public function payload(): ?TaskPayload
     {
         return $this->payload;
     }
 
+    /**
+     * Retorna o erro relacionado ao resultado, quando existir.
+     */
     public function error(): ?Throwable
     {
         return $this->error;

--- a/packages/redis/README.md
+++ b/packages/redis/README.md
@@ -1,0 +1,22 @@
+# bifrost/redis
+
+Cliente Redis opcional e reutilizavel para extensoes do Bifrost Framework.
+
+Use este pacote quando uma extensao precisar de Redis sem duplicar a logica de
+conexao. `RedisConnectionManager` reutiliza a mesma conexao para configuracoes
+iguais e permite trocar a factory por uma implementacao futura de cluster.
+
+```php
+use Bifrost\Extension\Redis\RedisConfig;
+use Bifrost\Extension\Redis\RedisExtension;
+
+$application->extend(new RedisExtension());
+
+$redis = $application->container()
+    ->get(Bifrost\Extension\Redis\Contracts\RedisConnectionFactory::class)
+    ->connect(RedisConfig::fromArray([
+        'host' => 'redis',
+        'port' => 6379,
+        'database' => 0,
+    ]));
+```

--- a/packages/redis/composer.json
+++ b/packages/redis/composer.json
@@ -1,17 +1,16 @@
 {
-  "name": "bifrost/cache-redis",
-  "description": "Adapter Redis opcional para cache no Bifrost Framework",
+  "name": "bifrost/redis",
+  "description": "Cliente Redis reutilizavel para extensoes opcionais do Bifrost Framework",
   "type": "library",
   "license": "MIT",
   "require": {
     "php": ">=8.1",
     "bifrost/framework": "^1.0",
-    "bifrost/redis": "^1.0",
     "ext-redis": "*"
   },
   "autoload": {
     "psr-4": {
-      "Bifrost\\Extension\\CacheRedis\\": "src/"
+      "Bifrost\\Extension\\Redis\\": "src/"
     }
   },
   "require-dev": {

--- a/packages/redis/phpunit.xml
+++ b/packages/redis/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php" colors="true">
+    <testsuites>
+        <testsuite name="Bifrost Redis">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/packages/redis/src/Contracts/RedisConnectionFactory.php
+++ b/packages/redis/src/Contracts/RedisConnectionFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bifrost\Extension\Redis\Contracts;
+
+use Bifrost\Extension\Redis\RedisConfig;
+use Redis;
+
+/**
+ * Cria conexoes Redis para extensoes opcionais.
+ */
+interface RedisConnectionFactory
+{
+    /**
+     * Retorna uma conexao Redis para a configuracao informada.
+     */
+    public function connect(RedisConfig $config): Redis;
+}

--- a/packages/redis/src/NativeRedisConnectionFactory.php
+++ b/packages/redis/src/NativeRedisConnectionFactory.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bifrost\Extension\Redis;
+
+use Bifrost\Extension\Redis\Contracts\RedisConnectionFactory;
+use Redis;
+use RuntimeException;
+
+/**
+ * Factory baseada na extensao nativa ext-redis.
+ */
+final class NativeRedisConnectionFactory implements RedisConnectionFactory
+{
+    public function connect(RedisConfig $config): Redis
+    {
+        $redis = new Redis();
+        $connected = $redis->connect($config->host, $config->port, $config->timeout);
+
+        if (!$connected) {
+            throw new RuntimeException('Nao foi possivel conectar ao Redis.');
+        }
+
+        if ($config->password !== null) {
+            $redis->auth($config->password);
+        }
+
+        if ($config->database !== null) {
+            $redis->select($config->database);
+        }
+
+        return $redis;
+    }
+}

--- a/packages/redis/src/NativeRedisConnectionFactory.php
+++ b/packages/redis/src/NativeRedisConnectionFactory.php
@@ -13,6 +13,9 @@ use RuntimeException;
  */
 final class NativeRedisConnectionFactory implements RedisConnectionFactory
 {
+    /**
+     * Abre uma conexao Redis usando ext-redis.
+     */
     public function connect(RedisConfig $config): Redis
     {
         $redis = new Redis();

--- a/packages/redis/src/RedisConfig.php
+++ b/packages/redis/src/RedisConfig.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bifrost\Extension\Redis;
+
+/**
+ * Configuracao de conexao Redis compartilhada por extensoes.
+ */
+final class RedisConfig
+{
+    public function __construct(
+        public readonly string $host = '127.0.0.1',
+        public readonly int $port = 6379,
+        public readonly float $timeout = 0.0,
+        public readonly ?string $password = null,
+        public readonly ?int $database = null
+    ) {
+    }
+
+    /**
+     * @param array{host?: string, port?: int|string, timeout?: float|int|string, password?: string|null, database?: int|string|null} $config
+     */
+    public static function fromArray(array $config): self
+    {
+        $password = $config['password'] ?? null;
+        $database = $config['database'] ?? null;
+
+        return new self(
+            host: (string) ($config['host'] ?? '127.0.0.1'),
+            port: (int) ($config['port'] ?? 6379),
+            timeout: (float) ($config['timeout'] ?? 0.0),
+            password: $password === null || $password === '' ? null : (string) $password,
+            database: $database === null || $database === '' ? null : (int) $database
+        );
+    }
+
+    /**
+     * Chave interna usada para reutilizar conexoes equivalentes.
+     */
+    public function fingerprint(): string
+    {
+        return hash('sha256', json_encode([
+            'host' => $this->host,
+            'port' => $this->port,
+            'timeout' => $this->timeout,
+            'password' => $this->password,
+            'database' => $this->database,
+        ], JSON_THROW_ON_ERROR));
+    }
+}

--- a/packages/redis/src/RedisConfig.php
+++ b/packages/redis/src/RedisConfig.php
@@ -9,6 +9,13 @@ namespace Bifrost\Extension\Redis;
  */
 final class RedisConfig
 {
+    /**
+     * @param string $host Host Redis.
+     * @param int $port Porta Redis.
+     * @param float $timeout Timeout de conexao em segundos.
+     * @param string|null $password Senha Redis opcional.
+     * @param int|null $database Banco Redis opcional.
+     */
     public function __construct(
         public readonly string $host = '127.0.0.1',
         public readonly int $port = 6379,

--- a/packages/redis/src/RedisConnectionManager.php
+++ b/packages/redis/src/RedisConnectionManager.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bifrost\Extension\Redis;
+
+use Bifrost\Extension\Redis\Contracts\RedisConnectionFactory;
+use Redis;
+
+/**
+ * Reutiliza conexoes Redis por configuracao.
+ */
+final class RedisConnectionManager implements RedisConnectionFactory
+{
+    /** @var array<string, Redis> */
+    private array $connections = [];
+
+    public function __construct(
+        private readonly RedisConnectionFactory $factory = new NativeRedisConnectionFactory()
+    ) {
+    }
+
+    public function connect(RedisConfig $config): Redis
+    {
+        $key = $config->fingerprint();
+
+        return $this->connections[$key] ??= $this->factory->connect($config);
+    }
+}

--- a/packages/redis/src/RedisConnectionManager.php
+++ b/packages/redis/src/RedisConnectionManager.php
@@ -15,11 +15,17 @@ final class RedisConnectionManager implements RedisConnectionFactory
     /** @var array<string, Redis> */
     private array $connections = [];
 
+    /**
+     * @param RedisConnectionFactory $factory Factory concreta usada ao abrir conexoes novas.
+     */
     public function __construct(
         private readonly RedisConnectionFactory $factory = new NativeRedisConnectionFactory()
     ) {
     }
 
+    /**
+     * Retorna uma conexao Redis reutilizada para a configuracao informada.
+     */
     public function connect(RedisConfig $config): Redis
     {
         $key = $config->fingerprint();

--- a/packages/redis/src/RedisExtension.php
+++ b/packages/redis/src/RedisExtension.php
@@ -13,10 +13,16 @@ use Bifrost\Framework\Contracts\Extension;
  */
 final class RedisExtension implements Extension
 {
+    /**
+     * @param RedisConnectionFactory|null $factory Factory customizada para Redis.
+     */
     public function __construct(private readonly ?RedisConnectionFactory $factory = null)
     {
     }
 
+    /**
+     * Registra a factory Redis compartilhada.
+     */
     public function register(Application $application): void
     {
         RedisServiceRegistrar::register($application, $this->factory);

--- a/packages/redis/src/RedisExtension.php
+++ b/packages/redis/src/RedisExtension.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bifrost\Extension\Redis;
+
+use Bifrost\Extension\Redis\Contracts\RedisConnectionFactory;
+use Bifrost\Framework\Application;
+use Bifrost\Framework\Contracts\Extension;
+
+/**
+ * Registra a factory Redis reutilizavel no container.
+ */
+final class RedisExtension implements Extension
+{
+    public function __construct(private readonly ?RedisConnectionFactory $factory = null)
+    {
+    }
+
+    public function register(Application $application): void
+    {
+        RedisServiceRegistrar::register($application, $this->factory);
+    }
+}

--- a/packages/redis/src/RedisServiceRegistrar.php
+++ b/packages/redis/src/RedisServiceRegistrar.php
@@ -12,6 +12,9 @@ use Bifrost\Framework\Application;
  */
 final class RedisServiceRegistrar
 {
+    /**
+     * Registra a factory Redis compartilhada se ainda nao houver uma no container.
+     */
     public static function register(Application $application, ?RedisConnectionFactory $factory = null): void
     {
         if ($application->container()->has(RedisConnectionFactory::class)) {

--- a/packages/redis/src/RedisServiceRegistrar.php
+++ b/packages/redis/src/RedisServiceRegistrar.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bifrost\Extension\Redis;
+
+use Bifrost\Extension\Redis\Contracts\RedisConnectionFactory;
+use Bifrost\Framework\Application;
+
+/**
+ * Garante um unico registro de conexoes Redis compartilhado entre extensoes.
+ */
+final class RedisServiceRegistrar
+{
+    public static function register(Application $application, ?RedisConnectionFactory $factory = null): void
+    {
+        if ($application->container()->has(RedisConnectionFactory::class)) {
+            return;
+        }
+
+        $application->container()->bind(
+            RedisConnectionFactory::class,
+            new RedisConnectionManager($factory ?? new NativeRedisConnectionFactory())
+        );
+    }
+}

--- a/packages/redis/tests/RedisConnectionManagerTest.php
+++ b/packages/redis/tests/RedisConnectionManagerTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+use Bifrost\Extension\Redis\Contracts\RedisConnectionFactory;
+use Bifrost\Extension\Redis\RedisConfig;
+use Bifrost\Extension\Redis\RedisConnectionManager;
+use Bifrost\Extension\Redis\RedisExtension;
+use Bifrost\Framework\Application;
+use PHPUnit\Framework\TestCase;
+
+final class RedisConnectionManagerTest extends TestCase
+{
+    public function testReusesConnectionForSameConfig(): void
+    {
+        $factory = new CountingRedisConnectionFactory();
+        $manager = new RedisConnectionManager($factory);
+        $config = new RedisConfig(host: 'redis', port: 6379, database: 0);
+
+        $first = $manager->connect($config);
+        $second = $manager->connect($config);
+
+        self::assertSame($first, $second);
+        self::assertSame(1, $factory->connections);
+    }
+
+    public function testCreatesDifferentConnectionsForDifferentConfigs(): void
+    {
+        $factory = new CountingRedisConnectionFactory();
+        $manager = new RedisConnectionManager($factory);
+
+        $first = $manager->connect(new RedisConfig(host: 'redis', port: 6379, database: 0));
+        $second = $manager->connect(new RedisConfig(host: 'redis', port: 6379, database: 1));
+
+        self::assertNotSame($first, $second);
+        self::assertSame(2, $factory->connections);
+    }
+
+    public function testExtensionDoesNotOverrideExistingFactory(): void
+    {
+        $application = Application::create();
+        $factory = new CountingRedisConnectionFactory();
+        $application->container()->instance(RedisConnectionFactory::class, $factory);
+
+        $application->extend(new RedisExtension());
+
+        self::assertSame($factory, $application->container()->get(RedisConnectionFactory::class));
+    }
+
+    public function testConfigNormalizesArrayValues(): void
+    {
+        $config = RedisConfig::fromArray([
+            'host' => 'redis',
+            'port' => '6380',
+            'timeout' => '1.5',
+            'password' => '',
+            'database' => '2',
+        ]);
+
+        self::assertSame('redis', $config->host);
+        self::assertSame(6380, $config->port);
+        self::assertSame(1.5, $config->timeout);
+        self::assertNull($config->password);
+        self::assertSame(2, $config->database);
+    }
+}
+
+final class CountingRedisConnectionFactory implements RedisConnectionFactory
+{
+    public int $connections = 0;
+
+    public function connect(RedisConfig $config): Redis
+    {
+        $this->connections++;
+
+        return new Redis();
+    }
+}

--- a/packages/redis/tests/bootstrap.php
+++ b/packages/redis/tests/bootstrap.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/../vendor/autoload.php';

--- a/packages/storage-local/src/LocalStorage.php
+++ b/packages/storage-local/src/LocalStorage.php
@@ -11,6 +11,9 @@ use RuntimeException;
 
 final class LocalStorage implements Storage
 {
+    /**
+     * @param string $rootPath Diretorio raiz onde os arquivos serao gravados.
+     */
     public function __construct(private readonly string $rootPath)
     {
         if (trim($this->rootPath) === '') {
@@ -18,6 +21,14 @@ final class LocalStorage implements Storage
         }
     }
 
+    /**
+     * Grava um conteudo no storage local.
+     *
+     * @param string $key Chave relativa do arquivo.
+     * @param string $body Conteudo a ser gravado.
+     * @param array<string, mixed> $options Opcoes reservadas para compatibilidade com Storage.
+     * @return array{Key: string, ContentLength: int}
+     */
     public function put(string $key, string $body, array $options = []): array
     {
         $key = $this->normalizedKey($key);
@@ -35,6 +46,13 @@ final class LocalStorage implements Storage
         return ['Key' => $key, 'ContentLength' => strlen($body)];
     }
 
+    /**
+     * Le um arquivo do storage local.
+     *
+     * @param string $key Chave relativa do arquivo.
+     * @param array<string, mixed> $options Opcoes reservadas para compatibilidade com Storage.
+     * @return array{Key: string, Body: string, ContentLength: int}
+     */
     public function get(string $key, array $options = []): array
     {
         $key = $this->normalizedKey($key);
@@ -52,6 +70,13 @@ final class LocalStorage implements Storage
         return ['Key' => $key, 'Body' => $body, 'ContentLength' => strlen($body)];
     }
 
+    /**
+     * Remove um arquivo do storage local.
+     *
+     * @param string $key Chave relativa do arquivo.
+     * @param array<string, mixed> $options Opcoes reservadas para compatibilidade com Storage.
+     * @return array{Key: string, Deleted: bool}
+     */
     public function delete(string $key, array $options = []): array
     {
         $key = $this->normalizedKey($key);
@@ -60,6 +85,13 @@ final class LocalStorage implements Storage
         return ['Key' => $key, 'Deleted' => !is_file($path) || unlink($path)];
     }
 
+    /**
+     * Retorna uma URL file:// para o arquivo local.
+     *
+     * @param string $key Chave relativa do arquivo.
+     * @param DateTimeImmutable|null $expiresAt Ignorado pelo storage local.
+     * @param array<string, mixed> $options Opcoes reservadas para compatibilidade com Storage.
+     */
     public function temporaryUrl(
         string $key,
         ?DateTimeImmutable $expiresAt = null,

--- a/packages/storage-local/src/LocalStorageExtension.php
+++ b/packages/storage-local/src/LocalStorageExtension.php
@@ -10,10 +10,16 @@ use Bifrost\Framework\Contracts\Storage;
 
 final class LocalStorageExtension implements Extension
 {
+    /**
+     * @param string $rootPath Diretorio raiz do storage local.
+     */
     public function __construct(private readonly string $rootPath)
     {
     }
 
+    /**
+     * Registra o storage local como implementacao de Storage.
+     */
     public function register(Application $application): void
     {
         $application->container()->bind(Storage::class, new LocalStorage($this->rootPath));

--- a/packages/storage-s3/README.md
+++ b/packages/storage-s3/README.md
@@ -17,6 +17,11 @@ $storage = $application->container()->get(Storage::class);
 $url = $storage->temporaryUrl('reports/example.txt');
 ```
 
+O pacote registra `S3ClientFactory` internamente e reutiliza clientes com a
+mesma configuracao via `S3ClientManager`. Para trocar a criacao do cliente,
+registre uma factory propria antes da extensao ou informe `clientFactory` no
+construtor.
+
 Este pacote e aditivo. Ele nao substitui `Bifrost\Interface\Storage`,
 `Bifrost\Integration\Storage\S3Storage` ou o alias legado
 `Bifrost\Integration\S3Storage` do modulo `bifrost/api`.

--- a/packages/storage-s3/src/Contracts/S3ClientFactory.php
+++ b/packages/storage-s3/src/Contracts/S3ClientFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bifrost\Extension\StorageS3\Contracts;
+
+use Aws\S3\S3Client;
+use Bifrost\Extension\StorageS3\S3ClientConfig;
+
+/**
+ * Cria clientes S3 para extensoes opcionais.
+ */
+interface S3ClientFactory
+{
+    /**
+     * Retorna um cliente S3 para a configuracao informada.
+     */
+    public function client(S3ClientConfig $config): S3Client;
+}

--- a/packages/storage-s3/src/FixedS3ClientFactory.php
+++ b/packages/storage-s3/src/FixedS3ClientFactory.php
@@ -12,10 +12,16 @@ use Bifrost\Extension\StorageS3\Contracts\S3ClientFactory;
  */
 final class FixedS3ClientFactory implements S3ClientFactory
 {
+    /**
+     * @param S3Client $client Cliente que sempre sera retornado.
+     */
     public function __construct(private readonly S3Client $client)
     {
     }
 
+    /**
+     * Retorna o cliente S3 informado no construtor.
+     */
     public function client(S3ClientConfig $config): S3Client
     {
         return $this->client;

--- a/packages/storage-s3/src/FixedS3ClientFactory.php
+++ b/packages/storage-s3/src/FixedS3ClientFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bifrost\Extension\StorageS3;
+
+use Aws\S3\S3Client;
+use Bifrost\Extension\StorageS3\Contracts\S3ClientFactory;
+
+/**
+ * Factory para clientes S3 ja criados pela aplicacao.
+ */
+final class FixedS3ClientFactory implements S3ClientFactory
+{
+    public function __construct(private readonly S3Client $client)
+    {
+    }
+
+    public function client(S3ClientConfig $config): S3Client
+    {
+        return $this->client;
+    }
+}

--- a/packages/storage-s3/src/NativeS3ClientFactory.php
+++ b/packages/storage-s3/src/NativeS3ClientFactory.php
@@ -12,6 +12,9 @@ use Bifrost\Extension\StorageS3\Contracts\S3ClientFactory;
  */
 final class NativeS3ClientFactory implements S3ClientFactory
 {
+    /**
+     * Cria um cliente S3 usando o AWS SDK oficial.
+     */
     public function client(S3ClientConfig $config): S3Client
     {
         return new S3Client($config->options());

--- a/packages/storage-s3/src/NativeS3ClientFactory.php
+++ b/packages/storage-s3/src/NativeS3ClientFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bifrost\Extension\StorageS3;
+
+use Aws\S3\S3Client;
+use Bifrost\Extension\StorageS3\Contracts\S3ClientFactory;
+
+/**
+ * Factory baseada no cliente oficial da AWS.
+ */
+final class NativeS3ClientFactory implements S3ClientFactory
+{
+    public function client(S3ClientConfig $config): S3Client
+    {
+        return new S3Client($config->options());
+    }
+}

--- a/packages/storage-s3/src/S3ClientConfig.php
+++ b/packages/storage-s3/src/S3ClientConfig.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bifrost\Extension\StorageS3;
+
+/**
+ * Configuracao do cliente S3.
+ */
+final class S3ClientConfig
+{
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function __construct(private readonly array $options)
+    {
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    public static function fromStorageConfig(array $config): self
+    {
+        unset($config['bucket']);
+        $config['version'] ??= 'latest';
+        $config['region'] ??= 'us-east-1';
+
+        return new self($config);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function options(): array
+    {
+        return $this->options;
+    }
+
+    /**
+     * Chave interna usada para reutilizar clientes equivalentes.
+     */
+    public function fingerprint(): string
+    {
+        return hash('sha256', serialize($this->normalizedValue($this->options)));
+    }
+
+    private function normalizedValue(mixed $value): mixed
+    {
+        if (is_array($value)) {
+            ksort($value);
+
+            return array_map(fn (mixed $item): mixed => $this->normalizedValue($item), $value);
+        }
+
+        if (is_object($value)) {
+            return [
+                'object' => $value::class,
+                'id' => spl_object_id($value),
+            ];
+        }
+
+        if (is_resource($value)) {
+            return [
+                'resource' => get_resource_type($value),
+                'id' => (int) $value,
+            ];
+        }
+
+        return $value;
+    }
+}

--- a/packages/storage-s3/src/S3ClientManager.php
+++ b/packages/storage-s3/src/S3ClientManager.php
@@ -15,11 +15,17 @@ final class S3ClientManager implements S3ClientFactory
     /** @var array<string, S3Client> */
     private array $clients = [];
 
+    /**
+     * @param S3ClientFactory $factory Factory concreta usada ao criar clientes novos.
+     */
     public function __construct(
         private readonly S3ClientFactory $factory = new NativeS3ClientFactory()
     ) {
     }
 
+    /**
+     * Retorna um cliente S3 reutilizado para a configuracao informada.
+     */
     public function client(S3ClientConfig $config): S3Client
     {
         $key = $config->fingerprint();

--- a/packages/storage-s3/src/S3ClientManager.php
+++ b/packages/storage-s3/src/S3ClientManager.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bifrost\Extension\StorageS3;
+
+use Aws\S3\S3Client;
+use Bifrost\Extension\StorageS3\Contracts\S3ClientFactory;
+
+/**
+ * Reutiliza clientes S3 por configuracao.
+ */
+final class S3ClientManager implements S3ClientFactory
+{
+    /** @var array<string, S3Client> */
+    private array $clients = [];
+
+    public function __construct(
+        private readonly S3ClientFactory $factory = new NativeS3ClientFactory()
+    ) {
+    }
+
+    public function client(S3ClientConfig $config): S3Client
+    {
+        $key = $config->fingerprint();
+
+        return $this->clients[$key] ??= $this->factory->client($config);
+    }
+}

--- a/packages/storage-s3/src/S3ServiceRegistrar.php
+++ b/packages/storage-s3/src/S3ServiceRegistrar.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bifrost\Extension\StorageS3;
+
+use Bifrost\Extension\StorageS3\Contracts\S3ClientFactory;
+use Bifrost\Framework\Application;
+
+/**
+ * Garante um unico registro de cliente S3 compartilhado entre extensoes.
+ */
+final class S3ServiceRegistrar
+{
+    public static function register(Application $application, ?S3ClientFactory $factory = null): void
+    {
+        if ($application->container()->has(S3ClientFactory::class)) {
+            return;
+        }
+
+        $application->container()->bind(
+            S3ClientFactory::class,
+            new S3ClientManager($factory ?? new NativeS3ClientFactory())
+        );
+    }
+}

--- a/packages/storage-s3/src/S3ServiceRegistrar.php
+++ b/packages/storage-s3/src/S3ServiceRegistrar.php
@@ -12,6 +12,9 @@ use Bifrost\Framework\Application;
  */
 final class S3ServiceRegistrar
 {
+    /**
+     * Registra a factory S3 compartilhada se ainda nao houver uma no container.
+     */
     public static function register(Application $application, ?S3ClientFactory $factory = null): void
     {
         if ($application->container()->has(S3ClientFactory::class)) {

--- a/packages/storage-s3/src/S3Storage.php
+++ b/packages/storage-s3/src/S3Storage.php
@@ -13,6 +13,10 @@ use RuntimeException;
 
 final class S3Storage implements Storage
 {
+    /**
+     * @param S3Client $client Cliente S3 usado nas operacoes.
+     * @param string $bucket Bucket padrao do storage.
+     */
     public function __construct(
         private readonly S3Client $client,
         private readonly string $bucket
@@ -22,6 +26,14 @@ final class S3Storage implements Storage
         }
     }
 
+    /**
+     * Envia um objeto para o bucket S3.
+     *
+     * @param string $key Chave do objeto.
+     * @param string $body Conteudo do objeto.
+     * @param array<string, mixed> $options Opcoes adicionais aceitas pelo AWS SDK.
+     * @return array<string, mixed>
+     */
     public function put(string $key, string $body, array $options = []): array
     {
         return $this->run('putObject', array_merge(
@@ -30,6 +42,13 @@ final class S3Storage implements Storage
         ));
     }
 
+    /**
+     * Recupera um objeto do bucket S3.
+     *
+     * @param string $key Chave do objeto.
+     * @param array<string, mixed> $options Opcoes adicionais aceitas pelo AWS SDK.
+     * @return array<string, mixed>
+     */
     public function get(string $key, array $options = []): array
     {
         return $this->run('getObject', array_merge(
@@ -38,6 +57,13 @@ final class S3Storage implements Storage
         ));
     }
 
+    /**
+     * Remove um objeto do bucket S3.
+     *
+     * @param string $key Chave do objeto.
+     * @param array<string, mixed> $options Opcoes adicionais aceitas pelo AWS SDK.
+     * @return array<string, mixed>
+     */
     public function delete(string $key, array $options = []): array
     {
         return $this->run('deleteObject', array_merge(
@@ -46,6 +72,13 @@ final class S3Storage implements Storage
         ));
     }
 
+    /**
+     * Cria uma URL temporaria assinada para leitura do objeto.
+     *
+     * @param string $key Chave do objeto.
+     * @param DateTimeImmutable|null $expiresAt Data de expiracao. Padrao: 15 minutos.
+     * @param array<string, mixed> $options Opcoes adicionais aceitas pelo AWS SDK.
+     */
     public function temporaryUrl(
         string $key,
         ?DateTimeImmutable $expiresAt = null,
@@ -66,6 +99,9 @@ final class S3Storage implements Storage
         return (string) $request->getUri();
     }
 
+    /**
+     * Retorna o cliente S3 usado pela instancia.
+     */
     public function client(): S3Client
     {
         return $this->client;

--- a/packages/storage-s3/src/S3StorageExtension.php
+++ b/packages/storage-s3/src/S3StorageExtension.php
@@ -5,25 +5,38 @@ declare(strict_types=1);
 namespace Bifrost\Extension\StorageS3;
 
 use Aws\S3\S3Client;
+use Bifrost\Extension\StorageS3\Contracts\S3ClientFactory;
 use Bifrost\Framework\Application;
+use Bifrost\Framework\Container;
 use Bifrost\Framework\Contracts\Extension;
 use Bifrost\Framework\Contracts\Storage;
 use InvalidArgumentException;
 
 final class S3StorageExtension implements Extension
 {
+    private readonly S3ClientConfig $clientConfig;
+
     public function __construct(
         private readonly array $config,
-        private readonly ?S3Client $client = null
+        private readonly ?S3Client $client = null,
+        private readonly ?S3ClientFactory $clientFactory = null
     ) {
+        $this->clientConfig = S3ClientConfig::fromStorageConfig($config);
     }
 
     public function register(Application $application): void
     {
+        $clientFactory = $this->clientFactory;
+        if ($clientFactory === null && $this->client !== null) {
+            $clientFactory = new FixedS3ClientFactory($this->client);
+        }
+
+        S3ServiceRegistrar::register($application, $clientFactory);
+
         $application->container()->bind(
             Storage::class,
-            fn (): S3Storage => new S3Storage(
-                client: $this->client ?? new S3Client($this->clientConfig()),
+            fn (Container $container): S3Storage => new S3Storage(
+                client: $container->get(S3ClientFactory::class)->client($this->clientConfig),
                 bucket: $this->bucket()
             )
         );
@@ -38,15 +51,5 @@ final class S3StorageExtension implements Extension
         }
 
         return $bucket;
-    }
-
-    private function clientConfig(): array
-    {
-        $config = $this->config;
-        unset($config['bucket']);
-        $config['version'] ??= 'latest';
-        $config['region'] ??= 'us-east-1';
-
-        return $config;
     }
 }

--- a/packages/storage-s3/src/S3StorageExtension.php
+++ b/packages/storage-s3/src/S3StorageExtension.php
@@ -16,6 +16,11 @@ final class S3StorageExtension implements Extension
 {
     private readonly S3ClientConfig $clientConfig;
 
+    /**
+     * @param array<string, mixed> $config Configuracao do bucket e do cliente S3.
+     * @param S3Client|null $client Cliente pronto, mantido para compatibilidade.
+     * @param S3ClientFactory|null $clientFactory Factory customizada para criar clientes S3.
+     */
     public function __construct(
         private readonly array $config,
         private readonly ?S3Client $client = null,
@@ -24,6 +29,9 @@ final class S3StorageExtension implements Extension
         $this->clientConfig = S3ClientConfig::fromStorageConfig($config);
     }
 
+    /**
+     * Registra Storage e a factory compartilhada de cliente S3.
+     */
     public function register(Application $application): void
     {
         $clientFactory = $this->clientFactory;

--- a/packages/storage-s3/tests/S3ClientFactoryTest.php
+++ b/packages/storage-s3/tests/S3ClientFactoryTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+use Aws\MockHandler;
+use Aws\Result;
+use Aws\S3\S3Client;
+use Bifrost\Extension\StorageS3\Contracts\S3ClientFactory;
+use Bifrost\Extension\StorageS3\S3ClientConfig;
+use Bifrost\Extension\StorageS3\S3ClientManager;
+use Bifrost\Extension\StorageS3\S3Storage;
+use Bifrost\Extension\StorageS3\S3StorageExtension;
+use Bifrost\Framework\Application;
+use Bifrost\Framework\Contracts\Storage;
+use PHPUnit\Framework\TestCase;
+
+final class S3ClientFactoryTest extends TestCase
+{
+    public function testManagerReusesClientForSameConfig(): void
+    {
+        $factory = new CountingS3ClientFactory();
+        $manager = new S3ClientManager($factory);
+        $config = S3ClientConfig::fromStorageConfig(['bucket' => 'uploads']);
+
+        $first = $manager->client($config);
+        $second = $manager->client($config);
+
+        self::assertSame($first, $second);
+        self::assertSame(1, $factory->clients);
+    }
+
+    public function testExtensionUsesSharedClientFactory(): void
+    {
+        $factory = new CountingS3ClientFactory();
+        $application = Application::create();
+        $application->container()->instance(S3ClientFactory::class, $factory);
+
+        $application->extend(new S3StorageExtension(['bucket' => 'uploads']));
+
+        $storage = $application->container()->get(Storage::class);
+
+        self::assertInstanceOf(S3Storage::class, $storage);
+        self::assertSame(1, $factory->clients);
+        self::assertSame('us-east-1', $factory->lastConfig?->options()['region']);
+    }
+
+    public function testExtensionKeepsInjectedClientCompatibility(): void
+    {
+        $client = $this->clientWithResults();
+        $application = Application::create()->extend(new S3StorageExtension(
+            config: ['bucket' => 'uploads'],
+            client: $client
+        ));
+
+        $storage = $application->container()->get(Storage::class);
+
+        self::assertInstanceOf(S3Storage::class, $storage);
+        self::assertSame($client, $storage->client());
+    }
+
+    private function clientWithResults(Result ...$results): S3Client
+    {
+        return new S3Client([
+            'credentials' => ['key' => 'key', 'secret' => 'secret'],
+            'handler' => new MockHandler($results),
+            'region' => 'us-east-1',
+            'version' => 'latest',
+        ]);
+    }
+}
+
+final class CountingS3ClientFactory implements S3ClientFactory
+{
+    public int $clients = 0;
+    public ?S3ClientConfig $lastConfig = null;
+
+    public function client(S3ClientConfig $config): S3Client
+    {
+        $this->clients++;
+        $this->lastConfig = $config;
+
+        return new S3Client([
+            'credentials' => ['key' => 'key', 'secret' => 'secret'],
+            'handler' => new MockHandler([new Result([])]),
+            'region' => 'us-east-1',
+            'version' => 'latest',
+        ]);
+    }
+}

--- a/skeleton/README.md
+++ b/skeleton/README.md
@@ -52,6 +52,9 @@ Os complementos podem ser combinados, por exemplo Redis e PostgreSQL:
 docker compose -f docker-compose.yml -f compose/redis.yml -f compose/postgresql.yml up --build
 ```
 
+Os pacotes `cache-redis` e `queue-redis` usam `bifrost/redis` internamente para
+reutilizar a conexao Redis quando a configuracao for igual.
+
 Os overlays instalam na imagem PHP apenas a extensao requerida pelo perfil.
 Escolha `CACHE_DRIVER=apcu` ou `CACHE_DRIVER=redis`; nao registre ambos como
 provider do mesmo contrato.

--- a/skeleton/app/Worker/ExampleTaskHandler.php
+++ b/skeleton/app/Worker/ExampleTaskHandler.php
@@ -9,6 +9,9 @@ use Bifrost\Extension\QueueWorker\TaskPayload;
 
 final class ExampleTaskHandler implements TaskHandler
 {
+    /**
+     * Processa uma tarefa de exemplo emitindo uma linha no stdout.
+     */
     public function handle(TaskPayload $payload): void
     {
         fwrite(STDOUT, sprintf("Tarefa %s processada.\n", $payload->task()));


### PR DESCRIPTION
## Objetivo
Preparar integrações externas para reutilização de conexões e evolução futura.

## Principais mudanças
- encapsula conexão Redis compartilhada entre cache e fila;
- reutiliza conexões Redis equivalentes;
- encapsula criação e reutilização de clientes S3;
- amplia PHPDocs e documentação Composer.

## Testes executados
- testes focados foram executados durante a implementação original;
- suíte modular completa pendente por timeout recente.

## Ordem de merge
PR 5. Depende do PR anterior.